### PR TITLE
[#108440080] Link to built/hosted site on Read the Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Government PaaS Team Manual
 
-This project uses [MkDocs][].
+This project uses [MkDocs][]. It is automatically built and hosted by [Read
+the Docs][] at the following URL:
+
+- https://government-paas-team-manual.readthedocs.org/
 
 [MkDocs]: http://www.mkdocs.org/
+[Read the Docs]: https://readthedocs.org/
 
 ## Setup
 


### PR DESCRIPTION
I set this up by:

1. Signing up for an RTD account.
2. Manually creating a new project (I didn't want to grant it access to my
GitHub account).
3. Giving it the public URL of this GitHub repo.
4. Changing the "documentation type" from Sphinx to MkDocs.
5. Disabling PDF and ePub builds, because I don't expect us to need them and
it will speed up the build process slightly.
6. Adding @alextomlins and @timothymower as "maintainers" who have admin
access to the settings.
7. Enable the service integration on the GitHub repo (it doesn't take any
settings, just on/off).