### PR TITLE
Update spruce guide now operand expressions PR is merged

### DIFF
--- a/docs/guides/spruce.md
+++ b/docs/guides/spruce.md
@@ -4,14 +4,10 @@ For more information, see the spruce readme and [examples](https://github.com/ge
 
 ## Installation
 
-For the time being we depend on the code in [this pull request](https://github.com/geofffranks/spruce/pull/69). This section will be updated once it is merged to master.
+You need to install spruce >= 0.13.0. This version added support for operand expressions.
 
 ```
-$ git clone https://github.com/geofffranks/spruce.git
-$ git checkout expr
-$ go get github.com/geofffranks/spruce # Fetches all the dependencies required for build step and installs them in $GOPATH
-$ go build
-$ mv spruce /usr/bin # Or any other directory in $PATH
+$ go get github.com/geofffranks/spruce # Builds spruce, including dependencies and puts it in $GOPATH/bin
 ```
 
 ## Default merge with simple keys
@@ -370,8 +366,6 @@ critical_key: critical_value
 ```
 
 ## *OR* operator
-Introduced in PR https://github.com/geofffranks/spruce/pull/69
-Tested successfully, it should be in master soon.
 
 Alows to specify alternate values in the first key is null. Compatible with `grab` and `concat`.
 

--- a/docs/guides/spruce.md
+++ b/docs/guides/spruce.md
@@ -10,6 +10,21 @@ You need to install spruce >= 0.13.0. This version added support for operand exp
 $ go get github.com/geofffranks/spruce # Builds spruce, including dependencies and puts it in $GOPATH/bin
 ```
 
+To upgrade spruce:
+
+```
+$ go get -u github.com/geofffranks/spruce
+```
+
+Note: If you previously built spruce from a branch, following instructions in a
+previous version of this guide, you may need to find and remove old
+copies of the `spruce` binary that were copied into your $PATH:
+
+```
+$ spruce -v     # if version 0.12.0 is reported, you probably built from the branch
+$ which spruce  # shows files you may need to remove
+```
+
 ## Default merge with simple keys
 
 ```


### PR DESCRIPTION
I was reading the spruce guide and noticed that the referenced PR was merged and released into spruce v0.13.0, so I updated the instructions to use go get to fetch the source instead of git.

I assumed we had no other reason to build from source.

I've tested that the OR operator example works after following the new installation steps.