### PR TITLE
[#109787160] Describe the types of AWS alerts

### DIFF
--- a/docs/team/responding_to_aws_alert.md
+++ b/docs/team/responding_to_aws_alert.md
@@ -1,3 +1,8 @@
 # Responding to AWS alerts
 
-The process for this is documented [here](https://docs.google.com/document/d/1ytziKl6MUcnN_4QlBYy0c6fm_uykm4T98qoam6SEE-k/edit).
+AWS now sends alerts to the team mailing list. These include:
+
+- Billing alerts
+- Notification that Amazon has detected that an access key is publicly available
+
+The process for responding to these is documented [here](https://docs.google.com/document/d/1ytziKl6MUcnN_4QlBYy0c6fm_uykm4T98qoam6SEE-k/edit).


### PR DESCRIPTION
So that team members have some idea of when to look at the process document.
This description has been copied from the first paragraph of the doc.