### PR TITLE
Refactor and extend PR guidance

### DIFF
--- a/docs/team/working_practices.md
+++ b/docs/team/working_practices.md
@@ -30,32 +30,19 @@ explains this in more detail.
 We peer review all code to ensure that it works as expected and is clear for
 the team to understand. All work, no matter how small, should use git
 branches and GitHub pull requests. [Anna's blog post][] explains how to
-raise a good pull request. Please also use the following template as the
-pull request description to help the person reviewing it:
-
-```
-## What
-
-Describe what you have changed and why.
-
-## How to review
-
-Describe the steps required to test the changes.
-
-## Who can review
-
-Describe who can review the changes. Or more importantly, list the people
-that can't review, because they worked on it.
-```
+raise a good pull request.
 
 [Anna's blog post]: http://www.annashipman.co.uk/jfdi/good-pull-requests.html
+[this template]: https://github.com/alphagov/paas-cf/blob/master/.github/PULL_REQUEST_TEMPLATE.md
 
-We record merged pull requests in Pivotal Tracker using a GitHub service
-integration, so that we can later see all of the code changes for a given
-story. When you create a pull request you should put the ID of the story in
-the title (format: `[#12345678] My pull request`) which will later form the
-merge commit. Please do not add the story ID to individual commits, as this
-creates a lot of noise in Pivotal.
+When you create a pull request please:
+
+- use [this template][] for the description so that it is easier for
+  the reviewer to understand and test your changes
+
+- prefix the subject with the story ID from Pivotal Tracker (format:
+  `[#12345678] My pull request`) so that we have a record of all the changes
+  for a given story
 
 There is a dashboard near our desks that displays open pull requests using
 [Fourth Wall][]. Reviewing outstanding pull requests should be a priority

--- a/docs/team/working_practices.md
+++ b/docs/team/working_practices.md
@@ -44,6 +44,10 @@ When you create a pull request please:
   `[#12345678] My pull request`) so that we have a record of all the changes
   for a given story
 
+- put the pull request URL into the Pivotal Tracker story so that
+  people can find it and understand the progress of a story before it is
+  merged
+
 There is a dashboard near our desks that displays open pull requests using
 [Fourth Wall][]. Reviewing outstanding pull requests should be a priority
 over picking up new work. As the author of a pull request you may still need


### PR DESCRIPTION
#### Refactor pull request guidance

- link to out pull request template in alphagov/paas-cf instead of
  duplicating here
- use bullet points for the things you need to do when creating a pull
  request

I've omitted the part about not putting story numbers on individual commits
because it came from a previous team in GDS where we did that and I don't
expect anyone new to this team would do that by default.

#### Put unmerged PR URLs into Pivotal

This came from a team discussion a few weeks ago. Possibly a retrospective.