### PR TITLE
Retro action: check for conflicting work at kickoff

### DIFF
--- a/docs/team/working_practices.md
+++ b/docs/team/working_practices.md
@@ -35,9 +35,11 @@ so that rotation are evenly distributed.
 # Story kick-off
 
 Kick-offs are an opportunity to clarify the scope of a story and raise any
-technical suggestions or concerns before work starts. When a pair starts a
-new story they should arrange a kick-off with the Business Analyst, Tech
-Arch or Tech Lead, and anyone else from the team that is interested. Slack
+technical suggestions or concerns before work starts. They should include a
+check if the story being kicked off will likely conflict with any of the
+stories already in progress and therefore liklely cause conflicts. When a pair
+starts a new story they should arrange a kick-off with the Business Analyst,
+Tech Arch or Tech Lead, and anyone else from the team that is interested. Slack
 is a good way to let the team know.
 
 # Commit messages


### PR DESCRIPTION
In our retrospective of 8/3/2016 we discussed some occasions when two stories
played at the same time changed the same lines of code in different ways. This
caused a number of merge conflicts that needed to be resolved before finished
stories could be merged into master.

We agreed that the best way to avoid difficult and time consuming merges was to
identify at kick-off time if was likely that the story being kicked off would
cause conflicts with a story already in play.