### PR TITLE
Update adding contractors to git instructions

### DIFF
--- a/docs/team/working_practices.md
+++ b/docs/team/working_practices.md
@@ -145,7 +145,8 @@ the API key from the "Profile" page of your own account.
     1. `team-government-paas-readonly`: the dashboard user which has
 `org:read` privileges to find all of our repos.
     1. `team-government-paas-contractors`: all members of the team that are
-contractors and aren't members of the `owners` team.
+contractors and aren't members of the `owners` team. These should be given write
+access.
 
 We should never pull request against the `master` branch of a forked repo.
 Doing so makes it very hard to reconcile our changes against the upstream


### PR DESCRIPTION
To specify write access.

This has caught me out a couple of times because the default in the
github ui is to give read access only, hopefully specifying this in the
manual should help