### PR TITLE
Update readthedocs domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project uses [MkDocs][]. It is automatically built and hosted by [Read
 the Docs][] at the following URL:
 
-- https://government-paas-team-manual.readthedocs.org/
+- https://government-paas-team-manual.readthedocs.io/
 
 [MkDocs]: http://www.mkdocs.org/
 [Read the Docs]: https://readthedocs.org/


### PR DESCRIPTION
I received an email from Read The Docs that says:

> Starting today, Read the Docs will start hosting projects from subdomains
> on the domain readthedocs.io, instead of on readthedocs.org. This change
> addresses some security concerns around site cookies while hosting user
> generated data on the same domain as our dashboard.

They do serve a redirect from the old to new domain, however they will
deprecate it one day and per rtfd/readthedocs.org#2175 the protocol isn't
preserved. So it's best that we update our links.

When merged I'll also update the URL in the repo description.