### PR TITLE
[#121502387] Update conditions for rotating pairs

### DIFF
--- a/docs/team/working_practices.md
+++ b/docs/team/working_practices.md
@@ -25,10 +25,15 @@ ensure that commits have been reviewed before deploying them.
 
 We pair on all stories to ensure that people don't get stuck on the same
 types of work and that there is a good distribution of knowledge across the
-team. We aim to rotate regularly, when starting new stories. However you can
-opt-out of a rotation if it would be detrimental to the progress of your
-current story. Please tick the [pair stair][] on our board when you rotate
-so that rotation are evenly distributed.
+team. We aim to rotate pairs regularly by:
+
+- changing pairs when you've been on a story for more than 2 days
+
+- joining someone on an existing story that doesn't have a pair instead of
+  picking up new work
+
+Please tick the [pair stair][] on our board when you rotate so that rotation
+are evenly distributed.
 
 [pair stair]: http://pairstair.com/
 


### PR DESCRIPTION
## What

We agreed these conditions in a retrospective because we found that people
were reluctant to change pairs. The 2 day rule ensures that people don't get
stuck on large stories and that we fresh ideas on existing problems. The
joining people ensures that people don't remain without a pair or wait until
standup for rotation.

## How to review

Read the new text and see if it makes sense. You can preview the rendering of the bullet points by following the instructions in the README.

## Who can review

Not @dcarley