### PR TITLE
[#121933113] - Document HAProxy healthcheck port on routers

### DIFF
--- a/docs/architecture_decision_records/ADR008-haproxy-for-request-rewriting.md
+++ b/docs/architecture_decision_records/ADR008-haproxy-for-request-rewriting.md
@@ -100,3 +100,6 @@ Consequences
 
  * Another moving part to monitor and take into account.
 
+### See Also
+
+[ADR012](ADR012-haproxy-healthcheck/)

--- a/docs/architecture_decision_records/ADR012-haproxy-healthcheck.md
+++ b/docs/architecture_decision_records/ADR012-haproxy-healthcheck.md
@@ -1,0 +1,51 @@
+
+Context
+=======
+
+Stories: [#123490171](https://www.pivotaltracker.com/story/show/123490171) & [#121933113](https://www.pivotaltracker.com/story/show/121933113)
+
+We were investigating how to avoid downtime to deployed applications when we
+made changes to the platform. We had discovered that short outages occurred
+when the gorouter was taken out of service.
+
+gorouter has drain functionality to allow upstream load balancers to gracefully
+take instances of the gorouter out of service before any requests start to
+fail.
+
+When a USR1 signal is sent to instruct the gorouter to start draining,
+healthchecking requests, identified by the header `User-Agent: HTTP-Monitor/1.1`
+start failing with HTTP 503. User requests are allowed to continue.
+
+Two things prevented us from using drain mode:
+
+- we had the ELB configured to use TCP healthchecks, not HTTP
+- the ELB sends HTTP healthcheck requests with `User-Agent:
+  ELB-HealthChecker/1.0`, which means they were not recognised as healthcheck
+  requests by gorouter, they returned HTTP 200 and the ELB did not take the
+  draining gorouter out of service.
+
+The result was a very small amount of downtime for deployed apps that received
+requests during a short window of < 1 second.
+
+Decision
+========
+
+We decided to:
+
+- submit a change upstream to [allow the gorouter to recognise ELB
+  healthchecks](https://github.com/cloudfoundry/gorouter/pull/138)
+- implement a healhchecking port 82, in the HAProxy we introduced in ADR008,
+  which appends the `User-Agent: HTTP-Monitor/1.1` that gorouter expects
+- enable HTTP healthchecks on the ELB
+
+
+Status
+======
+
+Accepted
+
+Consequences
+============
+
+- There was less downtime for deployed applications during a deploy.
+- We have an additional reason to keep the intermediate HAProxy we introduced as a temporary measure.


### PR DESCRIPTION
## What

Explain why we have a port 82 healthcheck port on HAProxy

## Why

We previously documented why we introduced HAProxy in front of the gorouter, so it's useful to capture our new reason for having HAProxy in place. 

I aksed the team and @keymon also thought this would be useful

## How to review

Read the words what I wrote and decide if they are accurate and understandable

## Who can review 

Anyone but @bleach