### PR TITLE
[#115884129] Check diego job ordering

### DIFF
--- a/docs/guides/upgrading_CF,_bosh_and_stemcells.md
+++ b/docs/guides/upgrading_CF,_bosh_and_stemcells.md
@@ -10,6 +10,7 @@
 * Check the [garden linux release documentation](https://github.com/cloudfoundry-incubator/garden-linux-release/releases)
 * Check the [bosh release documentation](https://github.com/cloudfoundry/bosh/releases)
 * Check the [stemcell release documentation](http://bosh.cloudfoundry.org/stemcells/)
+* Check the job ordering in the [Diego manifest](https://github.com/cloudfoundry/diego-release/blob/develop/manifest-generation/diego.yml) to see if our job ordering needs to change as well.
 * Use `git diff` in the `cf-release` repo to see example changes to the manifest templates. For example, to see differences between v228 and v233:
 ```
 git diff --exit-code -U5 --patience v228...v233 templates

--- a/docs/guides/upgrading_CF,_bosh_and_stemcells.md
+++ b/docs/guides/upgrading_CF,_bosh_and_stemcells.md
@@ -1,7 +1,7 @@
 ## Before Upgrading
 
-* Only upgrade one thing per pull request unless you have a very good reason not to. Upgrades can cause problems and our experience is that it is difficult to be certain about the cause of those problems if multiple things have changed. 
-* Establish the correct version to upgrade to. This will usually be the latest stable release minus two, subject to review of the version in question. The main driver for the current-minus-two strategy is to avoid the bad releases which CF produce from time to time. An alternative strategy may be to pick a release at least two weeks old, thereby giving Pivotal time to flag and pull and bad releases before we plough ahead with them. Kick-off is an appropriate place for this review. 
+* Only upgrade one thing per pull request unless you have a very good reason not to. Upgrades can cause problems and our experience is that it is difficult to be certain about the cause of those problems if multiple things have changed.
+* Establish the correct version to upgrade to. This will usually be the latest stable release minus two, subject to review of the version in question. The main driver for the current-minus-two strategy is to avoid the bad releases which CF produce from time to time. An alternative strategy may be to pick a release at least two weeks old, thereby giving Pivotal time to flag and pull and bad releases before we plough ahead with them. Kick-off is an appropriate place for this review.
 * Check [cf-release releases documentation](https://github.com/cloudfoundry/cf-release/releases) before upgrading to a particular version. There have been versions, such as [v232](https://github.com/cloudfoundry/cf-release/releases/tag/v232), where the release is not appropriate for production usage.
 * Refer to cf-release documentation for recommended versions of all related releases (for example, Diego and related components). Read the documentation for every release of all of these components. It will save you time and pain in the long run.
 * Check the [diego release documentation](https://github.com/cloudfoundry-incubator/diego-release/releases)
@@ -28,8 +28,8 @@ You should test the upgrade changeset:
 
 ## Problems encountered previously
 
-### DNS name resolution. 
-We encountered a wide variety of acceptance and smoke test failures which were intermittent. This was due to DNS health check failures. Consul uses these health checks to validate the consistency of the DNS records it serves, and will expire DNS records where the health check has failed. 
+### DNS name resolution.
+We encountered a wide variety of acceptance and smoke test failures which were intermittent. This was due to DNS health check failures. Consul uses these health checks to validate the consistency of the DNS records it serves, and will expire DNS records where the health check has failed.
 
 The root cause was failure to remove the `consul.agent.services` property for Diego components in the CloudFoundry manifest. [Diego release notes for version 1452](https://github.com/cloudfoundry-incubator/diego-release/releases/tag/v0.1452.0) did state these had to be removed, as Diego components now use the Locket library to configure its DNS health checks.
 
@@ -45,7 +45,7 @@ The upgrade to v233 has introduced some new tests in the acceptance-test suite, 
 
 We experienced failures in:
 
-* `routing` suite - The `multiple_app_ports` test fails if  `users_can_select_backend` is not set to `true` - The test receives a response of `CF-BackendSelectionNotAuthorized` which does not match the expected response of `CF-MultipleAppPortsMappedDiegoToDea` and causes the test to fail - This test should not be run unless the user is permitted to switch backends. We raised an issue with Pivotal for this test : 
+* `routing` suite - The `multiple_app_ports` test fails if  `users_can_select_backend` is not set to `true` - The test receives a response of `CF-BackendSelectionNotAuthorized` which does not match the expected response of `CF-MultipleAppPortsMappedDiegoToDea` and causes the test to fail - This test should not be run unless the user is permitted to switch backends. We raised an issue with Pivotal for this test :
 https://www.pivotaltracker.com/story/show/117685687
 https://github.com/cloudfoundry/cf-acceptance-tests/issues/104
 


### PR DESCRIPTION
## What

Add a reminder to check Diego job ordering when upgrading CloudFoundry. We need to do this now that we are following [the job ordering in the Diego manifest](https://github.com/cloudfoundry/diego-release/blob/v0.1476.0/manifest-generation/diego.yml#L122-L424).

## How to review

Read it. Make sure it makes sense.

## Who

Anyone but @alext or me.