### PR TITLE
Correct spruce install command

### DIFF
--- a/docs/guides/spruce.md
+++ b/docs/guides/spruce.md
@@ -7,13 +7,13 @@ For more information, see the spruce readme and [examples](https://github.com/ge
 You need to install spruce >= 0.13.0. This version added support for operand expressions.
 
 ```
-$ go get github.com/geofffranks/spruce # Builds spruce, including dependencies and puts it in $GOPATH/bin
+$ go get github.com/geofffranks/spruce/cmd/spruce # Builds spruce, including dependencies and puts it in $GOPATH/bin
 ```
 
 To upgrade spruce:
 
 ```
-$ go get -u github.com/geofffranks/spruce
+$ go get -u github.com/geofffranks/spruce/cmd/spruce
 ```
 
 Note: If you previously built spruce from a branch, following instructions in a


### PR DESCRIPTION
Simply installing github.com/geofffranks/spruce via `go get` only
installs the library into the GOPATH.

In order to install a binary we need to specify the path containing
the main package, which for spruce is
`github.com/geofffranks/spruce/cmd/spruce`