### PR TITLE
Update link to Getting Started Guide

### DIFF
--- a/docs/team/orientation.md
+++ b/docs/team/orientation.md
@@ -66,7 +66,7 @@ familiar with each one.
 
  What | Get started | Learn the concepts 
 ------|-------------|------------------------
-Cloud Foundry, as a user | [Our getting started guide](https://documentation.trial.cf.paas.alphagov.co.uk/) | [Considerations for application developers](http://docs.cloudfoundry.org/devguide/deploy-apps/prepare-to-deploy.html) 
+Cloud Foundry, as a user | [Our getting started guide](https://government-paas-developer-docs.readthedocs.io/en/latest/) | [Considerations for application developers](http://docs.cloudfoundry.org/devguide/deploy-apps/prepare-to-deploy.html) 
 [Concourse](http://concourse.ci/), the CI server we use for deployment | [Concourse tutorials](https://github.com/starkandwayne/concourse-tutorial) | [Concepts](http://concourse.ci/concepts.html)
 [BOSH](http://bosh.io/). It deploys Cloud Foundry and other things. | [A guide to using BOSH](http://mariash.github.io/learn-bosh/)  | [What problems does BOSH solve?](http://bosh.io/docs/problems.html) 
 Cloud Foundry, for those managing it | | [Cloud Foundry presentation, written by the team](https://docs.google.com/presentation/d/1LkR4Y3jLBQ8uskKeLIyKtSKDoutnAvty-vSSGfVNXZU/view), an [older presentation from before the move to Diego archecture](https://docs.google.com/presentation/d/1sZH1Nn_GiYfpBtT6br_AnZn_dynLzvYizJ9aQ4Zc1Ww/view)


### PR DESCRIPTION
The link to the Getting Started Guide was pointing at an old location.
Update to point at the current home.