### PR TITLE
[#119991203] Link to spreadsheet as canonical accounts list

### DIFF
--- a/docs/team/orientation.md
+++ b/docs/team/orientation.md
@@ -20,19 +20,13 @@ depend on, but this list should be enough to get you started.
 - [government-paas/credentials](https://github.gds/government-paas/credentials)
   (internal only)
 
-# URLs
+# Accounts
 
-These are the tools/services we use. The list roughly translates to things
-that new starters will need to be added to and leavers will need to be
-removed from.
+You will need accounts to a number of tools/services that we use such as
+GitHub and Pivotal Tracker. Government Digital Service staff can see a full
+list and their respective URLs in the following spreadsheet:
 
-- [Slack](https://govuk.slack.com/messages/the-government-paas/)
-- [Pivotal Tracker](https://www.pivotaltracker.com/n/projects/1275640)
-- [Google Group](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/the-multi-cloud-paas-team)
-- [Google Calendar](https://www.google.com/calendar/embed?src=digital.cabinet-office.gov.uk_4ga37koaoeoj4ah1kmi88oco9s%40group.calendar.google.com&ctz=Europe/London)
-- [GitHub.com](https://github.com/alphagov?utf8=%E2%9C%93&query=paas-)
-- [GitHub Enterprise](https://github.gds/government-paas)
-- [Docker Hub](https://hub.docker.com/u/governmentpaas)
+- [PaaS Team Checks](https://docs.google.com/spreadsheets/d/14gEh9jILg2p9aVIS78WTKEYMsz-ltetxnbugIw4TrWA/edit#gid=228343062)
 
 # Events
 


### PR DESCRIPTION
## What

This spreadsheet is now the canonical reference for what accounts a team
member *could* have and the URLs for accessing each one. By putting it in a
Google Doc we can be more comfortable about linking to semi-sensitive
information like our AWS account aliases. It will also become our reference
for starters and leavers, which should be more consistent than the Pivotal
Tracker tasks that we have at the moment.

## How to review

1. Check that the words make sense.
1. Check that you can see the spreadsheet.

## Who can review

Not @dcarley