### PR TITLE
Make it clear where to obtain the pivotal token

### DIFF
--- a/docs/team/working_practices.md
+++ b/docs/team/working_practices.md
@@ -239,7 +239,7 @@ ask a permanent member of the team to do this for you:
 forks of third-party repos which will need to be renamed after forking, e.g.
 `cf-release` would become `paas-cf-release`.
 1. Add the Pivotal Tracker service integration/hook. You will need to take
-the API key from the "Profile" page of your own account.
+the API key from the ["Profile" page](https://www.pivotaltracker.com/profile) of your own account.
 1. Add the following teams:
     1. `[team] Government PaaS readonly`: the dashboard user which has
 `org:read` privileges to find all of our repos.


### PR DESCRIPTION
What
====
I spent a few minutes clicking around to locate this, but the URL is static so we can link it from the team manual.

How to review it
============
Check the manual still renders and the link is correct.

Who can review it
=============
Not @jonty.