### PR TITLE
Fix broken chrome plugin link

### DIFF
--- a/docs/team/dashboard_mac_mini.md
+++ b/docs/team/dashboard_mac_mini.md
@@ -49,7 +49,7 @@ The combined dashboard is
 
 We're using a custom Chrome plugin to hide some of the Concourse page furniture
 on the Dashboard. It can be found
-[here](https://github.com/alphagov/paas-cf/tree/master/concourse/chrome_plugin).
+[here](https://github.com/alphagov/paas-cf/tree/master/misc/chrome_plugins/clean_concourse_pipeline).
 
 ## Pingdom
 


### PR DESCRIPTION
### What
We have moved chrome plugin location in paas-cf. Update the link.

### Reviewing
`mkdocs serve`, click on the link, should lead to correct destination

### Who
not me