### PR TITLE
[#129039813] Add ADR for SSL only policy and HSTS preload implementation

### DIFF
--- a/docs/architecture_decision_records/ADR443-ssl-only-for-applications-and-cf-endpoints.md
+++ b/docs/architecture_decision_records/ADR443-ssl-only-for-applications-and-cf-endpoints.md
@@ -1,0 +1,52 @@
+Context
+=======
+
+It is expected for the government websites to be secure and keep the user
+interactions private. Because that we want to enforce all communications to
+any application and to the platform endpoints to use only and always HTTPS.
+
+When a user inputs a website name without specifying the
+protocol in the URL, most browsers will try first the HTTP protocol by default.
+Even if the server always redirect HTTP to HTTPS, an initial
+unprotected request including user information will be transferred
+in clear: full URL with domain, parameter, cookies or browser meta-information.
+
+[HTTP Strict Transport Security](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security)
+mitigates this issue by instructing modern browsers that support it to
+always connect using HTTPS.
+
+There is still a potential initial unprotected HTTP request that might happen
+before retrieve the HSTS headers or after the specified HSTS `max-age`.
+To solve this issue, the root domain can be added to
+[HSTS preload list](https://hstspreload.appspot.com/) which will be used by most
+common browsers.
+
+Currently the only way to avoid any clear text HTTP interaction is closing or
+dropping any attempt to connect to the port 80 at TCP level.
+
+Decision
+========
+
+We will only open port 443 (HTTPS) and drop/reject any TCP connection to TCP port 80 (HTTP).
+
+We will implement and maintain HSTS preload lists for our production domains.
+
+
+Status
+======
+
+Accepted
+
+Consequences
+============
+
+We must configure and maintain our domain in the HSTS preload lists.
+
+Users of browsers which do not support HSTS, or HSTS preload lists, will not
+be able to connect to the sites without specify the protocol `https://` in
+the URL. This only happens when the user manually inputs the URL in the
+browser.
+
+
+
+

--- a/docs/architecture_decision_records/ADRXXX-hsts-preload-using-api-gateway.md
+++ b/docs/architecture_decision_records/ADRXXX-hsts-preload-using-api-gateway.md
@@ -1,0 +1,48 @@
+Context
+=======
+
+We will only [serve HTTPS traffic, keeping TCP port 80 (HTTP) closed and use HSTS preload lists](ADR443-ssl-only-for-applications-and-cf-endpoints.md).
+
+To add our domains to [HSTS preload lists](https://hstspreload.appspot.com/), there are these requirements:
+
+ 1. Serve a valid certificate.
+ 2. Redirect from HTTP to HTTPS on the same host.
+ 3. Serve all subdomains over HTTPS (actually checks for `www.domain.com`)
+ 4. Serve an HSTS header on the base domain for HTTPS requests:
+
+We cannot use the Cloud Foundry app endpoint, which already [serves the
+right HSTS Security header with HAProxy](ADR008-haproxy-for-request-rewriting.md)
+because we keep port 80 (HTTP) closed.
+
+We can implement a second ELB to listening on HTTP and HTTPS and use
+HAProxy to do the HTTP to HTTPS redirect and serve the right header.
+But this increases our dependency on the HAProxy service.
+
+We must serve from the root domain (or apex domain), but it is not allowed to
+serve [CNAME records in the root/apex domain](http://serverfault.com/questions/613829/why-cant-a-cname-record-be-used-at-the-apex-aka-root-of-a-domain). We must configure A records in this domain. This can be
+an issue when serving the service using ELB or CloudFront.
+
+Decision
+========
+
+ * We will implement a basic [AWS API Gateway](https://aws.amazon.com/api-gateway/)
+   with a default [MOCK response](https://aws.amazon.com/about-aws/whats-new/2015/09/introducing-mock-integration-generate-api-responses-from-api-gateway-directly/)
+   that returns the right HTTP header `Strict-Transport-Security`. The actual
+   content of the response is irrelevant, it can be a 302.
+   A [Custom Domain Name](http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html),
+   which creates a [AWS Cloud Front distribution](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-overview.html),
+   will provide public access to this API.
+
+ * We will use [AWS Route 53 `ALIAS` resource record](http://docs.aws.amazon.com/Route53/latest/APIReference/CreateAliasRRSAPI.html)
+  to [serve the IPs of the AWS Cloud Front distribution as A records](http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-cloudfront-distribution.html).
+
+
+Status
+======
+Accepted
+
+Consequences
+============
+
+To setup AWS API Gateway Domain Names, it is required access to the SSL certificates. There is the option of uploading the certificates in a different step and create the AWS Cloud Front distribution manually.
+


### PR DESCRIPTION
[#129039813 Implement HSTS Preload list requirements](https://www.pivotaltracker.com/n/projects/1275640/stories/129039813)

What
===

We want to serve only HTTPS for all endpoints and implement HSTS preload. Include 2 ADRs to describe the decisions taken:


 * Add ADR for HSTS preload using AWS API Gateway

   Describe the decisions taken to implement HSTS preload responder running on
   AWS API Gateway and Cloud Front.

 * Add ADR for SSL only for all endpoints

   Document the decision of only serve HTTPS/SSL connections to any public
   endpoint, for deployed applications or PaaS services.

How to review?
-----------

Read it, check if it makes sense

Who?
---

Anyone but @keymon