### PR TITLE
Document AWS notification mailing lists

### DIFF
--- a/docs/guides/common_support_tasks.md
+++ b/docs/guides/common_support_tasks.md
@@ -8,3 +8,7 @@ This guide contains instructions for common support tasks.
 4. Run `./paas-cf/scripts/rotate-user-password.sh -e prod -u user@example.com`
 
 The script will generate a new password for the user, change it, and then email them the password.
+
+## Subscribe and check the AWS notifications
+
+AWS [sends notifications to our maillists](../team/responding_to_aws_alert/). You should subscribe to these groups to get any notification.

--- a/docs/team/responding_to_aws_alert.md
+++ b/docs/team/responding_to_aws_alert.md
@@ -1,8 +1,16 @@
 # Responding to AWS alerts
 
-AWS now sends alerts to the team mailing list. These include:
+AWS now sends alerts to the teams mailing lists. These include:
 
 - Billing alerts
 - Notification that Amazon has detected that an access key is publicly available
+- EC2 Instances scheduled for retirement
+
+You can check and subscribe to these alerts in each corresponding mailing list page (Google Groups):
+
+- [Group for govpaas-awsnotifications-dev@digital.cabinet-office.gov.uk](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govpaas-awsnotifications-dev)
+- [Group for govpaas-awsnotifications-ci@digital.cabinet-office.gov.uk](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govpaas-awsnotifications-ci)
+- [Group for govpaas-awsnotifications-staging@digital.cabinet-office.gov.uk](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govpaas-awsnotifications-staging)
+- [Group for govpaas-awsnotifications-prod@digital.cabinet-office.gov.uk](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govpaas-awsnotifications-prod)
 
 The process for responding to these is documented [here](https://docs.google.com/document/d/1ytziKl6MUcnN_4QlBYy0c6fm_uykm4T98qoam6SEE-k/edit).


### PR DESCRIPTION
What?
----

We send our AWS notifications for the different accounts
to some mailing lists in Google Groups.

This commit documents this fact and links it to the common
support tasks.

How to review?
-----------

Render the docs as described in README.md. Do read-proofing

Who?
---

anyone but me