### PR TITLE
Document the new paas-alerts-{dev,ci,staging,prod} groups

### DIFF
--- a/docs/team/platform_alerting.md
+++ b/docs/team/platform_alerting.md
@@ -1,0 +1,11 @@
+# Responding to Platform Alerting
+
+Datadog is now being configured to send alerts to teams mailing lists.
+
+You can check and subscribe to these alerts in each corresponding mailing list page (Google Groups):
+
+- [Group for govpaas-alerting-dev@digital.cabinet-office.gov.uk](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govpaas-alerting-dev)
+- [Group for govpaas-alerting-ci@digital.cabinet-office.gov.uk](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govpaas-alerting-ci)
+- [Group for govpaas-alerting-staging@digital.cabinet-office.gov.uk](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govpaas-alerting-staging)
+- [Group for govpaas-alerting-prod@digital.cabinet-office.gov.uk](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govpaas-alerting-prod)
+


### PR DESCRIPTION
In playing
https://www.pivotaltracker.com/n/projects/1275640/stories/131355243 we
added new groups to send alerts to.  This is where they are.