### PR TITLE
Add a TOC to the working practices page.

### DIFF
--- a/docs/team/working_practices.md
+++ b/docs/team/working_practices.md
@@ -1,5 +1,7 @@
 # Development process
 
+[TOC]
+
 ![Illustration of changes being promoted to prod](../diagrams/development-process.svg)
 
 - The Product Manager makes decisions on what work (features, bugs) is


### PR DESCRIPTION
This page is quite large, so adding a table of contents at the top helps
with navigation.