### PR TITLE
[#132736941] Update mac-mini docs to mention smashing

### DIFF
--- a/docs/team/dashboard_mac_mini.md
+++ b/docs/team/dashboard_mac_mini.md
@@ -1,12 +1,18 @@
 # Dashboard Mac Mini
 
-There's a Mac Mini attached to big screens in our team area. It shows the
+There's a Mac Mini attached to big screens in our team area. It can show the
 following:
 
 * Outstanding pull requests
 * Grafana dashboard
 * Concourse pipelines
 * Pingdom public status page
+* Overview of Datadog triggered monitors
+
+Some combination of the above might be shown according to the whims of the team.
+If we want to display multiple different views on a single screen, we use
+[frame-splits](https://github.com/dsingleton/frame-splits), downloaded locally to the mac-mini to
+avoid worrying about sending sensitive urls to the outside world.
 
 If you need access, you can walk up and use the mouse and keyboard, or connect via the OSX Screen Sharing app.
 
@@ -62,3 +68,8 @@ on the Dashboard. It can be found
 We use the [Pingdom public status page](http://stats.pingdom.com/ejtodj13fqqx) ([documented here](https://help.pingdom.com/hc/en-us/articles/205386171-Public-Status-Page)) to display the uptime and current status of our healthcheck application. The Pingdom account is shared with other Government-as-a-Platform services, such as Notify, and there is only one shared dashboard for the entire account.
 
 We use the [Super Auto Refresh](https://chrome.google.com/webstore/detail/super-auto-refresh/kkhjakkgopekjlempoplnjclgedabddk?hl=en) Chrome extension to refresh the page.
+
+## PaaS Overview Dashboard
+
+We use [Smashing](https://github.com/Dashing-io/smashing) to build a dashboard
+summarising the state of environments in datadog. The dashboard code is in `paas-cf`.


### PR DESCRIPTION
We've introduced a new dashboard, and also decided on using
`frame-splits` if we need to display split-screen dashboards.

## Review

Check the docs make sense.
Review with https://github.com/alphagov/paas-cf/pull/587