### PR TITLE
Add link to the paas support manual

### DIFF
--- a/docs/guides/common_support_tasks.md
+++ b/docs/guides/common_support_tasks.md
@@ -1,5 +1,7 @@
 This guide contains instructions for common support tasks.
 
+The [PaaS Support Manual](https://docs.google.com/document/d/1Ui0MQtZbZnRCIj4RUdqCPU6PdWvfqY9FNf7Ou3OE99w) lives elsewehere, but should be moved into the team manual sometime soon.
+
 ## Changing a user's password
 
 1. Set your AWS environment variables to the production environment (assuming this is a production user)


### PR DESCRIPTION
Currently it lives in google docs.

We want to eventually move it to the team manual, we're tracking that in
https://www.pivotaltracker.com/n/projects/1275640/stories/127987443

We'll need to make sure existing editors are happy with git before we move it,
so just link for the moment.