### PR TITLE
Work around broken search integration

### DIFF
--- a/docs/js/fix_search.js
+++ b/docs/js/fix_search.js
@@ -1,0 +1,27 @@
+// See various broken search issues, but especially:
+// https://github.com/rtfd/readthedocs.org/pull/2289
+// https://github.com/rtfd/readthedocs.org/issues/1088
+
+function fixSearch() {
+  var target = document.getElementById('rtd-search-form');
+  var config = {attributes: true, childList: true};
+
+  var observer = new MutationObserver(function(mutations) {
+    observer.disconnect();
+    var form = $('#rtd-search-form');
+    form.empty();
+    form.attr('action', 'https://' + window.location.hostname + '/en/' + determineSelectedBranch() + '/search.html');
+    $('<input>').attr({
+      type: "text",
+      name: "q",
+      placeholder: "Search docs"
+    }).appendTo(form);
+  });
+  if (window.location.origin.indexOf('readthedocs') > -1) {
+    observer.observe(target, config);
+  }
+}
+
+$(document).ready(function () {
+  fixSearch();
+})


### PR DESCRIPTION
MkDocs and Readthedocs don't currently agree on how to do search.
This means that search has poor UX on the publically deployed docs
on readthedocs.io.

Here's a workaround suggested in github comments that we could use
to fix things for us while we wait for the two projects to reconcile.

See:
https://github.com/rtfd/readthedocs.org/pull/2289
https://github.com/rtfd/readthedocs.org/issues/1088


See also https://github.com/alphagov/paas-developer-docs/pull/32

Should we use this fix?