### PR TITLE
Include js fix for search in `extra_javascript`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,2 +1,4 @@
 site_name: Government PaaS Team Manual
 theme: readthedocs
+extra_javascript:
+  - js/fix_search.js


### PR DESCRIPTION
Although the js was already included running `mkdocs serve` locally,
it was not included on readthedocs.io

Perhaps this config option is what we need:
http://www.mkdocs.org/user-guide/configuration/#extra_javascript