### PR TITLE
Fix js used to fix search

### DIFF
--- a/docs/js/fix_search.js
+++ b/docs/js/fix_search.js
@@ -10,7 +10,7 @@ function fixSearch() {
     observer.disconnect();
     var form = $('#rtd-search-form');
     form.empty();
-    form.attr('action', 'https://' + window.location.hostname + '/en/' + determineSelectedBranch() + '/search.html');
+    form.attr('action', 'https://' + window.location.hostname + '/en/latest/search.html');
     $('<input>').attr({
       type: "text",
       name: "q",


### PR DESCRIPTION
We assumed the called function was provided by mkdocs/readthedocs,
but it is not.

Instead, we can hardcode to use the `latest` version, which should
be OK for long enough for us to switch away from mkdocs.