### PR TITLE
Document manual process for emailing tenants

### DIFF
--- a/docs/guides/common_support_tasks.md
+++ b/docs/guides/common_support_tasks.md
@@ -26,3 +26,9 @@ If Holly needs anything extra (for example, a Jenkins box provisioned) she will 
 You need admin access to `cf` in prod to do the reset.
 
 The script lives in `paas-cf`.
+
+## Notifying all users
+
+Occasionally you may need to notify all users of an event on the platform, perhaps during an incident in progress or to send an incident report.
+
+To do this, follow the instructions on [notifying tenants](../team/notifying_tenants/).

--- a/docs/team/notifying_tenants.md
+++ b/docs/team/notifying_tenants.md
@@ -43,6 +43,8 @@ done | grep '@' | sort | uniq
 
 ## Send the email
 
+**IMPORTANT: Remember to put the recipient list in `bcc:`!**
+
 We send the email from any team member's `gov.uk` GMail account.
 
 We use support email address as a non-alias to send from. To configure that for your account, follow these instructions:
@@ -51,4 +53,4 @@ We use support email address as a non-alias to send from. To configure that for 
 
 [Difference between alias and non-alias](https://support.google.com/a/answer/1710338?ctx=gmail&hl=en-GB&authuser=0&rd=1)
 
-**IMPORTANT: Remember to put the recipient list in `bcc:`!**
+*This bears repeating: use `bcc:`. No, not that one, that's `to:`. That's `cc:`. You got it, `bcc:`!*

--- a/docs/team/notifying_tenants.md
+++ b/docs/team/notifying_tenants.md
@@ -45,6 +45,8 @@ done | grep '@' | sort | uniq
 
 We send the email from any team member's `gov.uk` GMail account.
 
+We use support email address as a non-alias to send from. To configure that for your account, follow these instructions:
+
 [Setting up an alternative 'Send from' address](https://support.google.com/mail/answer/22370?hl=en)
 
 [Difference between alias and non-alias](https://support.google.com/a/answer/1710338?ctx=gmail&hl=en-GB&authuser=0&rd=1)

--- a/docs/team/notifying_tenants.md
+++ b/docs/team/notifying_tenants.md
@@ -1,0 +1,52 @@
+# Notifying tenants
+
+Every now and then, we need to let our tenants know something has happened or will happen on the platform.
+
+For example:
+
+* security problems and fixes
+* upgrades of CF, stemcells, buildpacks
+* incident reports
+
+At some point in the future, we will create an automated way of doing this, probably using [Notify](https://www.notifications.service.gov.uk/).
+
+We will probably also introduce better channels of communication - perhaps a status page, user forum, or explicit mailing list.
+
+Until then, our manual process is documented here.
+
+## Email draft
+
+Write the email you want to send.
+
+We don't have formal templates at the moment, but we have started to develop something approaching a 'house style' by example.
+
+Previous emails are stored in [Google Docs](https://drive.google.com/drive/folders/0Bw4pWpR0IbJfWGFEMVBBZlFsSDQ)
+
+Once you have your draft, get someone else on the team to proofread it.
+
+## Tenant addresses
+
+Find the list of tenant email addresses to send to by querying the platform.
+
+We don't yet have a better list of who should be notified than the list of CF users.
+
+Log in to the `prod` CF, then
+
+```
+for org in `cf orgs | tail -n+4`; do
+  cf target -o $org >/dev/null;
+  for space in `cf spaces 2>&1 | tail -n+4`; do
+    cf space-users $org $space;
+  done;
+done | grep '@' | sort | uniq
+```
+
+## Send the email
+
+We send the email from any team member's `gov.uk` GMail account.
+
+[Setting up an alternative 'Send from' address](https://support.google.com/mail/answer/22370?hl=en)
+
+[Difference between alias and non-alias](https://support.google.com/a/answer/1710338?ctx=gmail&hl=en-GB&authuser=0&rd=1)
+
+**IMPORTANT: Remember to put the recipient list in `bcc:`!**

--- a/docs/team/notifying_tenants.md
+++ b/docs/team/notifying_tenants.md
@@ -38,19 +38,15 @@ for org in `cf orgs | tail -n+4`; do
   for space in `cf spaces 2>&1 | tail -n+4`; do
     cf space-users $org $space;
   done;
-done | grep '@' | sort | uniq
+done | grep '@' | grep -v 'Getting users in org' | sort | uniq | sed 's/^  //'
 ```
 
 ## Send the email
 
 **IMPORTANT: Remember to put the recipient list in `bcc:`!**
 
-We send the email from any team member's `gov.uk` GMail account.
-
-We use support email address as a non-alias to send from. To configure that for your account, follow these instructions:
+We send the email from any team member's `gov.uk` GMail account, but with support email address as a non-alias to send from. To configure that for your account, follow these instructions:
 
 [Setting up an alternative 'Send from' address](https://support.google.com/mail/answer/22370?hl=en)
 
 [Difference between alias and non-alias](https://support.google.com/a/answer/1710338?ctx=gmail&hl=en-GB&authuser=0&rd=1)
-
-*This bears repeating: use `bcc:`. No, not that one, that's `to:`. That's `cc:`. You got it, `bcc:`!*


### PR DESCRIPTION
We've been doing this for a while, it's time we wrote it down.

This process will hopefully be superseded fairly soon, but now
we have a home for docs as the process is iterated.