### PR TITLE
[#136187337] Mention stack release in CF upgrade

### DIFF
--- a/docs/guides/upgrading_CF,_bosh_and_stemcells.md
+++ b/docs/guides/upgrading_CF,_bosh_and_stemcells.md
@@ -10,6 +10,8 @@
 * Check the [garden linux release documentation](https://github.com/cloudfoundry-incubator/garden-linux-release/releases)
 * Check the [bosh release documentation](https://github.com/cloudfoundry/bosh/releases)
 * Check the [stemcell release documentation](http://bosh.cloudfoundry.org/stemcells/)
+* Check the [stack release documentation](https://github.com/cloudfoundry/cflinuxfs2-rootfs-release/releases)
+* These releases may already be included in the main cf-release. Review if it makes sense to still use the separate release or switch to the standard one from cf-release instead.
 * Check the job ordering in the [Diego manifest](https://github.com/cloudfoundry/diego-release/blob/develop/manifest-generation/diego.yml) to see if our job ordering needs to change as well.
 * Use `git diff` in the `cf-release` repo to see example changes to the manifest templates. For example, to see differences between v228 and v233:
 ```


### PR DESCRIPTION
# What

Story: [Upgrade cflinuxfs2 stack](https://www.pivotaltracker.com/story/show/136187337)

The stack was recently upgraded because of CVEs. We should keep track of the stack as part of our standard CF upgrade process.

# How to review
Does it make sense?

# Who can review
Not me
