### PR TITLE
Remove DEPLOY_ENV from sts token filename.

### DIFF
--- a/docs/team/managing_aws_access.md
+++ b/docs/team/managing_aws_access.md
@@ -39,7 +39,7 @@ For example, you might add a function`:
 export PAAS_CF_DIR="path/to/paas-cf"
 
 sts() {
-  "${PAAS_CF_DIR}/scripts/create_sts_token.sh" && source "${HOME}/.aws_sts_tokens/${AWS_ACCOUNT}_${DEPLOY_ENV}.sh"
+  "${PAAS_CF_DIR}/scripts/create_sts_token.sh" && source "${HOME}/.aws_sts_tokens/${AWS_ACCOUNT}.sh"
 }
 ```
 


### PR DESCRIPTION
Following an update to the script, this is no longer included in the
filename.

This should be reviewed along with https://github.com/alphagov/paas-cf/pull/709