### PR TITLE
[#136783629] Update ADR009

### DIFF
--- a/docs/architecture_decision_records/ADR0015-end-to-end-encryption.md
+++ b/docs/architecture_decision_records/ADR0015-end-to-end-encryption.md
@@ -1,0 +1,27 @@
+Context
+=======
+
+In order to ensure the confidentiality of private tenant data processed on the platform we need to ensure that requests and responses for traffic between the user and application instances are encrypted so that it is not possible for a network eavesdropper to access private tenant data.
+
+There are 3 main network sections between the user and the application:
+
+* User to ELB
+* ELB to router
+* Router to cells
+
+Decision
+========
+
+* The traffic between the user and the ELB is encrypted by using an TLS listener on the ELB. A certificate issued by a certificate authority is set on the ELB and access to the private key is very restricted.
+* The ELB connects to the router VM via TLS. The router VM must, in consequence, serve TLS.
+* The router to application instances traffic is plain HTTP because the Cloud Foundry doesn't support TLS between gorouter and the application instances and the application instances may not talk TLS. We've decided to use IPSec on router and cell so the traffic will be encrypted transparently.
+
+Status
+======
+
+Accepted
+
+Consequences
+============
+
+The traffic is encrypted end-to-end between the user and the applications.

--- a/docs/architecture_decision_records/ADR009-x-forwarded-headers.md
+++ b/docs/architecture_decision_records/ADR009-x-forwarded-headers.md
@@ -1,20 +1,23 @@
+**This has been superceded: the first option is now used to encrypt traffic between the ELB and HAProxy (see ADR0015)**
+
 Context
 =======
 
 We need to pass correct client IP and requested protocol to applications deployed to the platform. To achieve this we want to use X-Forwarded-For and X-Forwarded-Proto headers.
-In the current setup we've got HAProxy behind ELB to allow insert HSTS headers, and ELB is configured in SSL mode (not HTTPS) because it does not support WebSockets. In SSL/TCP mode ELB is not able to set any `X-Forwarded` header. 
+In the current setup we've got HAProxy behind ELB to allow insert HSTS headers, and ELB is configured in SSL mode (not HTTPS) because it does not support WebSockets. In SSL/TCP mode ELB is not able to set any `X-Forwarded` header.
 
 The solution is to use ProxyProtocol to pass information about recorded client IP and protocol to HAProxy which can set required headers for us. Unfortunately [ELB sets ProxyProtocol header inside SSL stream and HAProxy expects it outside](http://serverfault.com/questions/775010/aws-elb-with-ssl-backend-adds-proxy-protocol-inside-ssl-stream).
 
-There are two options to workaround this: 
- * Use a more complex configuration of HAProxy with two frontends/listeners chained 
+There are two options to workaround this:
+
+ * Use a more complex configuration of HAProxy with two frontends/listeners chained
  * Disable SSL between ELB and HAProxy
 
 
 Decision
 ========
 
-We have decided to disable SSL encryption between internal IP of ELB and HAProxy to allow us to use ProxyProtocol. 
+We have decided to disable SSL encryption between internal IP of ELB and HAProxy to allow us to use ProxyProtocol.
 We don't think this has any significant increase in risk because:
 
 * gorouter to cell traffic is already HTTP (it has to be because we can't do termination in app containers)
@@ -28,4 +31,4 @@ Accepted
 Consequences
 ============
 
-The http traffic between ELB and HAProxy will not be encrypted. 
+The http traffic between ELB and HAProxy will not be encrypted.


### PR DESCRIPTION
# What
Story: [How do encrypt traffic between the elb and gorouter using haproxy](https://www.pivotaltracker.com/story/show/136783629)

https://github.com/alphagov/paas-cf/pull/713 and
https://github.com/alphagov/paas-haproxy-release/pull/8 encrypt the traffic between the router ELB and HAProxy.
The ADR is updated to reflect the change.

# How to review
Does it make sense?

# Who can review
Not @keymon or me
