### PR TITLE
[#136550911] Doc to create the CF security datadog integration

### DIFF
--- a/docs/team/cf_security_rss.md
+++ b/docs/team/cf_security_rss.md
@@ -1,0 +1,20 @@
+## CloudFoundry CVEs and Datadog
+
+CloudFoundry has a [page dedicated to security](https://www.cloudfoundry.org/category/security/) where published CVEs are listed. They offer an [RSS feed](https://www.cloudfoundry.org/category/security/feed/) so alerting can be automated.
+
+Datadog offers an [RSS integration](http://docs.datadoghq.com/integrations/rss/) that can monitor an RSS feed and create an event for each new published content. By combining it with the [event monitor](https://www.datadoghq.com/blog/event-alerts-another-way-to-trigger-notifications/) we can get notified for each new alert.
+
+The RSS integration was set up manually as there is no [Datadog API](http://docs.datadoghq.com/api/) for that. The monitor is created via terraform. If triggered, it emails Deskpro to create a ticket for each new CVE.
+
+## How to configure the RSS integration
+
+1. Login to Datadog with an admin account
+1. Go to [integrations](https://app.datadoghq.com/account/settings#integrations)
+1. Locate the RSS integration and click to install (or configure if already installed)
+1. Click on the `Configuration` tab
+1. Configure the integration by entering:
+    1. Feed URL: https://www.cloudfoundry.org/category/security/feed/
+    1. Custom Tags: cve,service:pivotal
+1. Click `Update configuration`
+
+The new CVEs should now show up as events in Datadog.

--- a/docs/team/responding_to_security_issues.md
+++ b/docs/team/responding_to_security_issues.md
@@ -4,17 +4,18 @@ Periodically we will learn of a security issue affecting CloudFoundry or our sup
 
 ## How we learn of issues
 
-* Automated datadog CVE notifications from our [Pivotal CVE notifier](https://github.com/alphagov/paas-cve-notifier)
+* Automated datadog CVE notifications from the [CloudFoundry security RSS feed](cf_security_rss)
 * Notifications from [cf-dev](https://lists.cloudfoundry.org/archives/list/cf-dev@lists.cloudfoundry.org/)
 * Notifications in slack from a team member, the #security channel, or others
 
 ## How we deal with issues
 
 1. The person on support should immediately create a Pivotal story with all the currently known information
-2. The person on support should post a link to the story in #paas-incident and notify the main #the-government-paas channel that a security incident is in progress
-3. The person on support should either immediately triage the issue themselves, or request support from team members with appropriate domain knowledge (See: "How to triage an issue" below)
-4. If the triage outcome is that we must take action the story should be prioritised according to severity by the product manager and played if necessary
-5. All PR's related to the security issue are prioritised for review until the issue is fully resolved
+1. If a Deskpro ticket was raised, add the story link to the ticket and close the ticket
+1. The person on support should post a link to the story in #paas-incident and notify the main #the-government-paas channel that a security incident is in progress
+1. The person on support should either immediately triage the issue themselves, or request support from team members with appropriate domain knowledge (See: "How to triage an issue" below)
+1. If the triage outcome is that we must take action the story should be prioritised according to severity by the product manager and played if necessary
+1. All PR's related to the security issue are prioritised for review until the issue is fully resolved
 
 ## How to triage an issue
 


### PR DESCRIPTION
# What

Story: [Review & improve CF CVE notifications](https://www.pivotaltracker.com/story/show/136550911)

Doc to create the CF security datadog integration and updates to the "responding to security issues".

# How to review
Does it make sense?

# Who can review
Not me
