### PR TITLE
How to deal with uncontactable org managers

### DIFF
--- a/docs/guides/common_support_tasks.md
+++ b/docs/guides/common_support_tasks.md
@@ -32,3 +32,19 @@ The script lives in `paas-cf`.
 Occasionally you may need to notify all users of an event on the platform, perhaps during an incident in progress or to send an incident report.
 
 To do this, follow the instructions on [notifying tenants](../team/notifying_tenants/).
+
+## Uncontactable Org Managers
+
+If none of the org managers for a specific org are contactable (for example if they've all left) then the following people within the team are permitted to approve the nomination of another person to be org manager:
+
+- Product Manager
+- Delivery Manager
+- Technical Architect
+
+Factors in their decision:
+
+- if the org is used for trial/prototyping or live use
+- if they are able to make contact with other senior members of the team to whom the org belongs
+- if the email account belonging to the absent org manager can be made active again to send an email authorising the change.
+
+We will also email every user currently in the organisation to explain what has been done.


### PR DESCRIPTION
## What

In https://gaap.deskpro.com/agent/#app.tickets,t:3627 we discovered that
someone who was the sole org manager for a trial organisation had left that
organisation.

Documenting what we decided to do in this and future cases.

## Who can review

Anyone who does support, apart from me

## How to review 

- Is it clear what to do?
- Does @urmishah or Jess agree with the process?