### PR TITLE
[#136435555] Notifying tenants

### DIFF
--- a/docs/team/notifying_tenants.md
+++ b/docs/team/notifying_tenants.md
@@ -8,12 +8,6 @@ For example:
 * upgrades of CF, stemcells, buildpacks
 * incident reports
 
-At some point in the future, we will create an automated way of doing this, probably using [Notify](https://www.notifications.service.gov.uk/).
-
-We will probably also introduce better channels of communication - perhaps a status page, user forum, or explicit mailing list.
-
-Until then, our manual process is documented here.
-
 ## Email draft
 
 Write the email you want to send.

--- a/docs/team/notifying_tenants.md
+++ b/docs/team/notifying_tenants.md
@@ -1,46 +1,108 @@
 # Notifying tenants
 
-Every now and then, we need to let our tenants know something has happened or will happen on the platform.
-
-For example:
+Every now and then, we need to let our tenants know something has happened or will happen on the platform. For example:
 
 * security problems and fixes
 * upgrades of CF, stemcells, buildpacks
 * incident reports
+* ongoing incidents
 
 ## Email draft
 
-Write the email you want to send.
+Write a draft email using a [template](#templates) as required and share it for example in [Google Docs](https://drive.google.com/drive/folders/0Bw4pWpR0IbJfWGFEMVBBZlFsSDQ).
 
-We don't have formal templates at the moment, but we have started to develop something approaching a 'house style' by example.
-
-Previous emails are stored in [Google Docs](https://drive.google.com/drive/folders/0Bw4pWpR0IbJfWGFEMVBBZlFsSDQ)
-
-Once you have your draft, get someone else on the team to proofread it.
-
-## Tenant addresses
-
-Find the list of tenant email addresses to send to by querying the platform.
-
-We don't yet have a better list of who should be notified than the list of CF users.
-
-Log in to the `prod` CF, then
-
-```
-for org in `cf orgs | tail -n+4`; do
-  cf target -o $org >/dev/null;
-  for space in `cf spaces 2>&1 | tail -n+4`; do
-    cf space-users $org $space;
-  done;
-done | grep '@' | grep -v 'Getting users in org' | sort | uniq | sed 's/^  //'
-```
+Then get someone else on the team to proofread it.
 
 ## Send the email
 
-**IMPORTANT: Remember to put the recipient list in `bcc:`!**
+Use the [google group interface](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/?hl=en#!forum/gov-uk-paas-announce) to send the email.
 
-We send the email from any team member's `gov.uk` GMail account, but with support email address as a non-alias to send from. To configure that for your account, follow these instructions:
+* Click on `New topic`
+* In `By` select: Post on behalf of GOV.UK PaaS announce
+* The `Subject` should help identify immediately the purpose of the email.
+Ex: "Incident with..."
+* In `Type of post` select: "Make an announcement" to emphasize this is
+one way communication
+* Body: paste the content of the reviewed draft. You may have to adjust formatting.
 
-[Setting up an alternative 'Send from' address](https://support.google.com/mail/answer/22370?hl=en)
+## Templates
 
-[Difference between alias and non-alias](https://support.google.com/a/answer/1710338?ctx=gmail&hl=en-GB&authuser=0&rd=1)
+In general you can follow this basic format:
+
+* What are we doing
+* Why are we doing it
+* Action the user needs to take
+
+The equivalent for incidents would be:
+
+* What is happening (that we know)
+* What we are doing
+* Any action the user should take (or things we know they *shouldn't* do)
+
+### We're having an incident
+
+```
+Hello,
+
+We are aware of and investigating a problem with GOV.UK PaaS.
+[Summarise problem and scale]
+[Summarise consequences for tenants AND end users]
+
+We will update you as soon as we know more information. In the meantime,
+if you do need any help, you can contact us via our help desk:
+gov-uk-paas-support@digital.cabinet-office.gov.uk.
+
+Apologies for the inconvenience.
+
+Regards,
+GOV.UK PaaS
+```
+
+### Incident update
+
+```
+Hello,
+
+We are actively working on the issue.
+[Summarise problem and scale]
+[Detail consequences for tenants AND end users]
+
+[Explain what has been done so far to investigate]
+[Mention any support case opened with our providers (AWS, DNS...)]
+
+[Mention any action the user should take]
+[Mention things we know they should not do]
+[Explain workarounds for broken things]
+
+We will update you as soon as we know more information. In the meantime,
+if you do need any help, you can contact us via our help desk:
+gov-uk-paas-support@digital.cabinet-office.gov.uk.
+
+Apologies for the inconvenience.
+
+Regards,
+GOV.UK PaaS
+```
+
+### Incident over
+
+
+```
+Hello,
+
+We are letting you know that there were problems with GOV.UK PaaS [insert time period].
+
+[Summarise problem and how we fixed it]
+[Detail consequences for tenants AND end users]
+
+In the coming days we will publish an incident report detailing the
+timeline of events, root cause, lessons learned and actions we will be taking to improve robustness of the platform.
+
+If you notice any issue, you can always contact us via our help desk:
+gov-uk-paas-support@digital.cabinet-office.gov.uk.
+
+Apologies for the inconvenience.
+
+Regards,
+GOV.UK PaaS
+```


### PR DESCRIPTION
# What

Story: [Improve incident comms](https://www.pivotaltracker.com/story/show/136435555)

Detailed instructions for notifying tenants, especially in case of an incident.

# How to review
Does it make sense?

# Who can review
Not me
