### PR TITLE
[#140553003] Test rotating credentials when doing CF upgrades

### DIFF
--- a/docs/guides/upgrading_CF,_bosh_and_stemcells.md
+++ b/docs/guides/upgrading_CF,_bosh_and_stemcells.md
@@ -27,6 +27,8 @@ You should test the upgrade changeset:
 * Deploying a fresh CF, which is something we frequently do in our
   development environments after the autodelete-cloufoundry pipeline
   runs overnight.
+* Confirm that [rotating credentials](../team/rotating_credentials.md) still
+  works and doesn't cause additional downtime during deployments.
 
 ## Problems encountered previously
 


### PR DESCRIPTION
## What

New releases can introduce new passwords or different uses of existing
passwords. It's possible that these may not be easy to rotate without
causing downtime. We'd like to know if this is the case before we next need
to use the credential rotation in anger (e.g. leaked secrets).

This was originally part of a follow-up story but I've pulled it out after a
discussion in knowledge share because we're likely to do one or more CF
upgrades before we play the follow-up to rotate more credentials.

## How to review

Confirm that:
- new text makes sense
- is in an appropriate place in the guide
- is a sensible thing for us to do.
- the link to another page in the team manual works

I'll remove the documentation part from the story when merged.

## Who can review

Not @dcarley