### PR TITLE
[#139179971] Add a note to notify tenants after upgrade

### DIFF
--- a/docs/guides/upgrading_CF,_bosh_and_stemcells.md
+++ b/docs/guides/upgrading_CF,_bosh_and_stemcells.md
@@ -30,6 +30,20 @@ You should test the upgrade changeset:
 * Confirm that [rotating credentials](../team/rotating_credentials.md) still
   works and doesn't cause additional downtime during deployments.
 
+## Notify the tenants
+
+After the upgrade we should notify the tenants by sending an email with these details:
+
+ - From: Government PaaS Support <gov-uk-paas-support@digital.cabinet-office.gov.uk>
+ - To: "GOV.UK PaaS Announce" <gov-uk-paas-announce@digital.cabinet-office.gov.uk>
+ - Subject: GOV.UK PaaS - Cloud Foundry changes - 17th March 2017
+
+The body should contain:
+
+ - Changes and bugfixes to highlight and new features enabled.
+ - Downtime or service impact if any
+ - Summary of buildpack changes. In order to retrieve the buildpack notes, you can use the script [`paas-cf/scripts/generate_buildpack_release_notes.sh`]
+
 ## Problems encountered previously
 
 ### DNS name resolution.


### PR DESCRIPTION
What?
----

We want to add some notes about how to notify tenants after a CF upgrade.

Include reference to the generate_buildpack_release_notes.sh script added in https://github.com/alphagov/paas-cf/pull/829

How to review?
---------

Read it, check that makes sense :)

Who?
----

Anyone but @keymon or @csaliceti