### PR TITLE
[#136027405] update team manual with google login workaround details

### DIFF
--- a/docs/guides/cf_admin_users.md
+++ b/docs/guides/cf_admin_users.md
@@ -5,6 +5,18 @@ able to attribute actions to individuals.
 
 In order to ensure two factor authentication is used, we use our google apps accounts to authenticate:
 
-`cf login --sso`
+`cf login -a api.SYSTEM_DOMAIN --sso`
 
-At present, a bug in UAA means that a workaround is necessary. This is [documented here](https://github.com/alphagov/paas-cf/pull/830#issue-214424527)
+At present, a [bug](https://github.com/cloudfoundry/uaa/issues/562) in UAA means that you will see an error like this:
+
+![Screenshot showing invalid redirect_uri error from google](https://camo.githubusercontent.com/4df4a3816727d2d6376df5d8bfe0f416446e22ae/68747470733a2f2f692e696d6775722e636f6d2f543268777076752e706e67)
+
+to fix this, edit the `redirect_uri` url parameter, which has had the login server hostname removed from it.
+
+Change it from:
+
+`redirect_uri=https%3A%2F%2Flogin%2Fcallback%2Fgoogle`
+
+to
+
+`redirect_uri=https%3A%2F%2Flogin.SYSTEM_DOMAIN%2Flogin%2Fcallback%2Fgoogle`

--- a/docs/guides/cf_admin_users.md
+++ b/docs/guides/cf_admin_users.md
@@ -1,0 +1,10 @@
+
+Everyone in the team who is authorised for prod access gets their own admin
+account in CI, staging and prod to avoid needing to share credentials and to be
+able to attribute actions to individuals.
+
+In order to ensure two factor authentication is used, we use our google apps accounts to authenticate:
+
+`cf login --sso`
+
+At present, a bug in UAA means that a workaround is necessary. This is [documented here](https://github.com/alphagov/paas-cf/pull/830#issue-214424527)


### PR DESCRIPTION
## What

A workaround will be required to login to admin accounts. Update the team manual to enable people to find the workaround to login easily.

## How to review

Ensure the meaning is clear. I have tested the instructions myself in the course of reviewing alphagov/paas-cf#830

If you like you may delay merging this change until alphagov/paas-cf#830 is merged, as the instructions won't work until that's been rolled out. However it seems unlikely that anyone will read them before we do roll it out anyway.

## Who can review

A team member who is not me



