### PR TITLE
[#139179971] Move upgrade notification to the relevant page

### DIFF
--- a/docs/guides/upgrading_CF,_bosh_and_stemcells.md
+++ b/docs/guides/upgrading_CF,_bosh_and_stemcells.md
@@ -32,17 +32,7 @@ You should test the upgrade changeset:
 
 ## Notify the tenants
 
-After the upgrade we should notify the tenants by sending an email with these details:
-
- - From: Government PaaS Support <gov-uk-paas-support@digital.cabinet-office.gov.uk>
- - To: "GOV.UK PaaS Announce" <gov-uk-paas-announce@digital.cabinet-office.gov.uk>
- - Subject: GOV.UK PaaS - Cloud Foundry changes - 17th March 2017
-
-The body should contain:
-
- - Changes and bugfixes to highlight and new features enabled.
- - Downtime or service impact if any
- - Summary of buildpack changes. In order to retrieve the buildpack notes, you can use the script [`paas-cf/scripts/generate_buildpack_release_notes.sh`]
+Send an email to users following [the upgrade template](../team/notifying_tenants.md#cf-upgrade).
 
 ## Problems encountered previously
 

--- a/docs/team/notifying_tenants.md
+++ b/docs/team/notifying_tenants.md
@@ -106,3 +106,14 @@ Apologies for the inconvenience.
 Regards,
 GOV.UK PaaS
 ```
+
+### CF upgrade
+
+Subject (ex): GOV.UK PaaS - Cloud Foundry changes - 17th March 2017
+
+The body should contain:
+
+ - Changes and bugfixes to highlight and new features enabled.
+ - Downtime or service impact if any
+ - Summary of buildpack changes. In order to retrieve the buildpack notes, you can use the script:
+`paas-cf/scripts/generate_buildpack_release_notes.sh`


### PR DESCRIPTION
# What

Story: [Upgrade CF to >= v252](https://www.pivotaltracker.com/story/show/139179971)

The CF upgrade notification part was added earlier to the upgrade section. It was decided it makes more sense to move it to the notification page.

# How to review

Does is make sense?

# Who can review
Not me