### PR TITLE
[#137700363] Describe manual setup for emergency support

### DIFF
--- a/docs/team/deskpro.md
+++ b/docs/team/deskpro.md
@@ -1,0 +1,31 @@
+[Deskpro](https://www.deskpro.com/) is the GaaP support tool. Each team customises it for its needs.
+
+You need to be admin to change the settings.
+
+*Basic manual setup should be documented here*
+
+## Emergencies
+
+## Email account
+
+A `@gaap.deskpro.com` [email account](https://gaap.deskpro.com/admin/admin-interface#/tickets/ticket_accounts) is set up for emergencies. We don't currently use an `@digital.cabinet-office.gov.uk` address because we aren't confident that emails won't get caught by moderation and spam filters.
+
+* The priority is set to `P1`.
+* It has an action `Send email`:
+  * Send to the emergency Pagerduty address
+  * Based on template `gov-uk-paas-emergency.html`
+* Set Email Account: normal support email address (otherwise the conversation continues on the emergency email address)
+
+## Custom email template
+
+The [custom email template](https://gaap.deskpro.com/admin/admin-interface#/tickets/email_templates/custom) is called `gov-uk-paas-emergency.html`.
+
+The subject and body can be edited. See the [documentation](https://manuals.deskpro.com/html/admin/editing-templates/email-templates.html) for more information. In particular, [predefined](https://gaap.deskpro.com/admin/admin-interface#/setup/phrases-default) or [custom phrases](https://manuals.deskpro.com/html/admin/editing-templates/intro-templates.html#custom-phrases) can be inserted as well as [template variables](https://manuals.deskpro.com/html/admin/editing-templates/template-variables.html).
+
+To make the Pagerduty alert meaningful, the content should show at least:
+
+* Original email subject
+* Original email body
+* Link to the Deskpro ticket
+* Ticket author
+* Ticket creation date and time

--- a/docs/team/pagerduty.md
+++ b/docs/team/pagerduty.md
@@ -36,7 +36,11 @@ The team email notification is added at the end as well to cover any potential g
 ## Services
 
 We integrate with Pingdom and Datadog. For each integration we create one *in hours* service that uses the in hours only escalation policy, and one *24x7* service that uses the 24x7 escalation policy.
-Incidents are not auto resolved. Only high-urgency notification rules are used.
+
+A special service called *Emergency email* is dedicated to urgent platform issues impacting tenants. It is triggered by tenants sending an email via Deskpro. The incoming emails are filtered by checking the sender via regular expression.
+It is attached to the *24x7* escalation policy.
+
+For all services, incidents are not auto resolved and only high-urgency notification rules are used.
 
 ## Manage rota
 


### PR DESCRIPTION
# What

Story: [Set up emergency email for tenants to use when alerting us OOH](https://www.pivotaltracker.com/story/show/137700363)

* Pageduty emergency service setup
* New "Deskpro" section. Only the setup for emergency is documented. The basic setup should be added later on

# How to review

* Does it make sense?
* Do links work?
* Is the real setup the same as described?

# Who can review
Not me
