### PR TITLE
[#145266177] Update the URL for GitHub Enterprise

### DIFF
--- a/docs/architecture_decision_records/ADR003-AWS-credentials.md
+++ b/docs/architecture_decision_records/ADR003-AWS-credentials.md
@@ -53,7 +53,7 @@ addresses.
 The IAM roles, profiles, and policies will be managed by our
 [aws-account-wide-terraform][] repo.
 
-[aws-account-wide-terraform]: https://github.gds/government-paas/aws-account-wide-terraform
+[aws-account-wide-terraform]: https://github.digital.cabinet-office.gov.uk/government-paas/aws-account-wide-terraform
 
 Status
 ======

--- a/docs/team/dashboard_mac_mini.md
+++ b/docs/team/dashboard_mac_mini.md
@@ -31,12 +31,12 @@ To get the URL for our dashboard, you can use these commands:
 
 ```
 export GITHUB_API_TOKEN=<your github access token>
-export GITHUB_GDS_API_TOKEN=<your github.gds access token>
+export GITHUB_GDS_API_TOKEN=<your github.digital.cabinet-office.gov.uk access token>
 
-echo "https://alphagov.github.io/fourth-wall/?token=${GITHUB_API_TOKEN}&team=alphagov/team-government-paas-readonly&github.gds_token=${GITHUB_GDS_API_TOKEN}&github.gds_team=government-paas/read-only"
+echo "https://alphagov.github.io/fourth-wall/?token=${GITHUB_API_TOKEN}&team=alphagov/team-government-paas-readonly&github.digital.cabinet-office.gov.uk_token=${GITHUB_GDS_API_TOKEN}&github.digital.cabinet-office.gov.uk_team=government-paas/read-only"
 ```
 
-Replace the placeholders with read-only [access tokens](https://github.com/blog/1509-personal-api-tokens) from github and github.gds.
+Replace the placeholders with read-only [access tokens](https://github.com/blog/1509-personal-api-tokens) from github and github.digital.cabinet-office.gov.uk.
 
 You can store those variables in a [password manager like `paas`](https://www.passwordstore.org/) and load then as needed.
 

--- a/docs/team/orientation.md
+++ b/docs/team/orientation.md
@@ -17,7 +17,7 @@ depend on, but this list should be enough to get you started.
 
 - [alphagov/paas-cf](https://github.com/alphagov/paas-cf)
 - [alphagov/paas-team-manual](https://github.com/alphagov/paas-team-manual)
-- [government-paas/credentials](https://github.gds/government-paas/credentials)
+- [government-paas/credentials](https://github.digital.cabinet-office.gov.uk/government-paas/credentials)
   (internal only)
 
 # Accounts


### PR DESCRIPTION
## What

It moved to a "real" hostname with a real certificate on the evening of
2017-05-11 as described in this announcement:

- https://sites.google.com/a/digital.cabinet-office.gov.uk/gds-internal-it/github-enterprise-change-5-30pm-6pm-11th-may-2017/githubdigitalcabinet-officegovuk

## How to review

Code review only.

## Who can review

Not @dcarley