### PR TITLE
[#147123069] Changed process for incident comms

### DIFF
--- a/docs/support/support_manual.md
+++ b/docs/support/support_manual.md
@@ -77,7 +77,7 @@ Always notify the tenant about this change and why it is done.
 * Let the user know that they can always reopen the ticket if required.
 
 ## Incident Process
-This section covers incidents and outages where the priority is to ensure HA service, it gives an overview of what you should be aware of before you are faced with an incident.
+This section covers incidents and outages where the priority is to ensure HA service, it gives an overview of what you should be aware of before you are faced with an incident. It also outlines how to manage incident comms.
 
 *Triaging and responding to security vulnerabilities is below [TODO]*
 
@@ -109,11 +109,10 @@ Ensure that we schedule the post mortem and publish our incident report Draft th
 ### If you’re incident comms:
 
 1. Let the PaaS team know about the incident on #the-government-paas Slack channel
-2. Send a summary of the incident as soon as possible to the [GaaP incidents email list](gaap-incidents@digital.cabinet-office.gov.uk) (this tells the GaaP team and a few others - internal to GDS - including IA team members). See the instructions below for what to include.
-3. Log in to our [Statuspage account](https://www.statuspage.io/). This is where you will send the incident alert email from, using the [saved templates](https://manage.statuspage.io/pages/h4wt7brwsqr0)
-4. Follow the [Notifying Tenants]((https://government-paas-team-manual.readthedocs.io/en/latest/team/notifying_tenants/)) guidelines for writing and sending the incident alert to tenants
-5. Update tenants hourly using the templates saved in our account.
-6. Ensure that all decisions/comms are in the timeline of the incident report.
+2. Send a summary of the incident as soon as possible to the [GaaP incidents email list](gaap-incidents@digital.cabinet-office.gov.uk) (this tells the GaaP team and a few others - internal to GDS - including IA team members).
+3. Log in to our [Statuspage account](https://www.statuspage.io/). This is where you will send the incident alert email from, using the [saved templates](https://manage.statuspage.io/pages/h4wt7brwsqr0).
+5. Update tenants hourly using the templates saved in our statuspage account.
+6. Ensure that all decisions/comms are entered into the timeline section of the incident report.
 
 [PaaS Emergency contacts and escalations document](https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/1_6zxOjvwY-zrf1D8eDNT9AeRhlcPAocBhC8dmHfRw0Y/edit?usp=sharing) *(restricted access)* provides useful contact information for senior GaaP management escalations for out of hours support.
 

--- a/docs/support/support_manual.md
+++ b/docs/support/support_manual.md
@@ -16,7 +16,7 @@ We’re supporting live services, teams who are using PaaS for prototyping and i
 
 TO BE COMPLETED (e.g. Concourse build status, User impact dashboard + datadog dashboard, New support cases in deskpro/your mail).
 
-### Alerting out of hours.
+### Alerting out of hours
 
 These are the things we support out of hours:
 
@@ -45,7 +45,7 @@ The following questions should be answered when triaging/prioritising:
 * In the event that none of the above people are available, you should use the triage questions to make a decision based on the information you have at the time.
 
 ## Severity Levels
-We classify issues by their impact to users (tenants and their users, PaaS team) and react accordingly. This allows us to set expectations about how we will work, and what other teams should expect.
+We classify issues by their impact to users (tenants and their users, and the PaaS team) and react accordingly. This allows us to set expectations about how we will work, and what other teams should expect.
 
 For most types of issue, our priority is to ensure high availability of the service.
 
@@ -67,9 +67,9 @@ You can access our [support ticketing tool Deskpro here](https://gaap.deskpro.co
 
 If you don’t have an account ask Urmi to add you. You can adjust your notifications yourself.
 
-### Tips and good practice.
+### Tips and good practice
 
-* Try to keep a descriptive name in the deskpro cards. If the user added a not very descriptive name (e.g failure pushing app), change it to something that uniquely identifies the story (e.g failure pushing app: invalid mode 0444).
+* Try to keep a descriptive name in the Deskpro cards. If the user added a not very descriptive name (e.g failure pushing app), change it to something that uniquely identifies the story (e.g failure pushing app: invalid mode 0444).
 Always notify the tenant about this change and why it is done.
 * Try to close the tickets if there is no action required from us.
 * If we are waiting for a card in the backlog, add add note in the card to saying that we need to inform the user once is done and accepted.
@@ -81,24 +81,26 @@ This section covers incidents and outages where the priority is to ensure HA ser
 
 *Triaging and responding to security vulnerabilities is below [TODO]*
 
-### If we’re having an incident.
+### If we’re having an incident
 
-1. Nominate an incident lead (this may be you)
-2. Nominate an incident comms person (during OOH this can be the person on the PaaS escalation rota)
-3. Join #paas-incident on Slack
-4. Get on with understanding and fixing the issue
+If you are on support when an incident happens, you should:
 
-The incident lead, comms and anyone else needed to work on the incident will form the incident team.
+1. nominate an incident lead (this may be you)
+2. nominate an incident comms person (during OOH this can be the person on the PaaS escalation rota)
+3. join #paas-incident on Slack
+4. get on with understanding and fixing the issue
+
+The incident lead, comms person and anyone else needed to work on the incident will form the incident team.
 
 The incident team can request support from any other members of the PaaS team and fixing the incident is usually more important than routine meetings (1 to 1s, retrospectives, planning, etc).
 
 ### If you’re the incident lead:
 
-Start making notes of what you’re doing - the #paas-incident Slack channel is the best place for this - so that the incident comms can start putting them in the incident report. Note, slack messages can start to disappear after a few days.
+Start making notes of what you’re doing - the #paas-incident Slack channel is the best place for this - so that the incident comms can start putting them in the incident report. It's worth bearing in mind that Tenants may know there's a problem and may join this channel. Also note, slack messages can start to disappear after a few days.
 
 Decide if you need people to help, and ask for them to come over and sit with you. Many people can investigate at the same time, but only the incident lead should be making changes to production.
 
-Consult the product manager and delivery manager to decide when the matter is not longer impacting the service, and is therefore resolved, or can be downgraded
+Consult the product manager and delivery manager to decide when the matter is not longer impacting the service, and is therefore resolved, or can be downgraded.
 
 Create a pivotal story to track our response to the incident. This should be used to keep a record of what we do to resolve the problem.
 
@@ -106,25 +108,26 @@ Ensure that we schedule the post mortem and publish our incident report Draft th
 
 ### If you’re incident comms:
 
-1. Let the PaaS team know on #the-government-paas Slack channel
-2. Send a summary of the incident as soon as possible to the [GaaP incidents email list](gaap-incidents@digital.cabinet-office.gov.uk) (this tells the GaaP team and a few others - internal to GDS - includes IA team members). See the instructions below for what to include.
-3. Send a summary of the incident to our tenants. For guidelines follow instructions under [Notifying tenants](https://government-paas-team-manual.readthedocs.io/en/latest/team/notifying_tenants/)
-4. Update tenants hourly using the instructions above.
-5. Update the [PaaS status page](https://status.cloud.service.gov.uk/) by logging into [Statuspage.io](https://manage.statuspage.io/pages/h4wt7brwsqr0)
+1. Let the PaaS team know about the incident on #the-government-paas Slack channel
+2. Send a summary of the incident as soon as possible to the [GaaP incidents email list](gaap-incidents@digital.cabinet-office.gov.uk) (this tells the GaaP team and a few others - internal to GDS - including IA team members). See the instructions below for what to include.
+3. Log in to our [Statuspage account](https://www.statuspage.io/). This is where you will send the incident alert email from, using the [saved templates](https://manage.statuspage.io/pages/h4wt7brwsqr0)
+4. Follow the [Notifying Tenants]((https://government-paas-team-manual.readthedocs.io/en/latest/team/notifying_tenants/)) guidelines for writing and sending the incident alert to tenants
+5. Update tenants hourly using the templates saved in our account.
 6. Ensure that all decisions/comms are in the timeline of the incident report.
 
-[PaaS Emergency contacts and escalations document](https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/1_6zxOjvwY-zrf1D8eDNT9AeRhlcPAocBhC8dmHfRw0Y/edit?usp=sharing) *(restricted access)* provides useful contact information for escalations for out of hours support.
+[PaaS Emergency contacts and escalations document](https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/1_6zxOjvwY-zrf1D8eDNT9AeRhlcPAocBhC8dmHfRw0Y/edit?usp=sharing) *(restricted access)* provides useful contact information for senior GaaP management escalations for out of hours support.
 
 
-## When the incident is over.
+## When the incident is over
+
+When the problem has been fixed, check that our [status page](https://status.cloud.service.gov.uk/) is showing that the PaaS is operational.
 
 ### Incident Report
 The [incident report template](https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/155yrsyhHM9Feh-ucxLzyj7toIb2sMK8KiGVdEFLcyfQ/edit?usp=sharing) gives some guidance about how to complete it.
 
 The incident lead and incident comms should ensure that the report is completed and that all relevant details are in the timeline.
 
-
-### Incident Review meeting.
+### Incident Review meeting
 
 This is a no-blame retro of the incident. See [blameless postmortems](https://codeascraft.com/2012/05/22/blameless-postmortems/) for some background.
 
@@ -142,6 +145,7 @@ This decision should be made by two of DM/PM/TL/TA.
 By default we publish Incident Reports on the [GaaP Blog](https://governmentasaplatform.blog.gov.uk/) unless there is a good reason not to. This approach is consistent across Data Group - it is similar to how GOV.UK publishes its reports. It sets a good example and demonstrates openness, which is a good thing. We just need to make sure we consider any negative ramifications.
 
 The only incidents for which this is not automatically true are for security incidents which need to be carefully considered in order to ensure that no further harm could be caused by publishing these.
+
 ### Editing for publication
 
 Create a copy of our factual incident report which can be edited for publication and send it to Nettie in the GaaP comms team.
@@ -150,9 +154,9 @@ The GaaP comms team will edit to ensure it is suitable for the audience. This wi
 The comms team will agree publication with the cabinet office press office.
 
 
-## Escalations.
+## Escalations
 
-If there is a P1 incident, the GaaP team will have been informed via the GaaP incidents email list, and will be kept updated via the PaaS Announce email list.
+If there is a P1 incident, the GaaP programme team will have been informed via the GaaP incidents email list, and will be kept updated via the PaaS Announce email list.
 
 If an incident needs to be escalated beyond the PaaS team, the incident comms person will contact people in the following order:
 
@@ -163,7 +167,7 @@ The person contacted above will decide if they need to alert a member of the GDS
 
 * David Lewis - Director for GDS Portfolio Group
 
-The contact details above information as well as useful contacts can be found in
+The contact details for the above people, as well as useful contacts, can be found in
 [PaaS Emergency contacts and escalations (restricted access)](https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/1_6zxOjvwY-zrf1D8eDNT9AeRhlcPAocBhC8dmHfRw0Y/edit?usp=sharing)
 
 ## Useful links

--- a/docs/team/notifying_tenants.md
+++ b/docs/team/notifying_tenants.md
@@ -1,19 +1,31 @@
 # Notifying tenants
 
-Every now and then, we need to let our tenants know something has happened or will happen on the platform. For example:
+Every now and then, we need to let our tenants know that something has happened or will happen on the platform. For example, letting teams know about security fixes, CF/stemcell/buildpack upgrades, new features and incidents.
 
-* security problems and fixes
-* upgrades of CF, stemcells, buildpacks
-* incident reports
-* ongoing incidents
+Depending on what it is we want to tell users, we have two different channels for sending these notifications:
 
-## Email draft
+* incident alerts and reports are sent using [our Statuspage account](https://manage.statuspage.io/pages/h4wt7brwsqr0)
+* changes, fixes and upgrades are sent using the [GOV.UK PaaS Announce Google group](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/?hl=en#!forum/gov-uk-paas-announce)
+* new feature announcements are sent using the [GOV.UK PaaS Announce Google group](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/?hl=en#!forum/gov-uk-paas-announce)
 
-Write a draft email using a [template](#templates) as required and share it for example in [Google Docs](https://drive.google.com/drive/folders/0Bw4pWpR0IbJfWGFEMVBBZlFsSDQ).
+## Sending incident alerts and updates
 
-Then get someone else on the team to proofread it.
+Follow the guidance in [this section](https://government-paas-team-manual.readthedocs.io/en/latest/support/support_manual/#if-youre-incident-comms) of the team manual if you're managing incident comms and you need to send alerts and updates to tenants. 
 
-## Send the email
+## Sending platform change and new feature announcements
+
+### Changes, upgrades and fixes
+
+Write a draft email and share it [here.](https://drive.google.com/drive/folders/0Bw4pWpR0IbJfWGFEMVBBZlFsSDQ)
+
+Get Tom or Jess to proof-read and add any 'product-y' elements - we want to make sure our notifications are consistent and meet the GDS style guidelines. If the email is time-sensitive and Tom/Jess are not around, get another member of the team to proof-read the email before it's sent.
+
+### Announcing new features
+
+These announcements are our chance to showcase how we're developing GOV.UK PaaS and will be written and sent by the product managers. Tom/Jess may ask the team member who worked on the story to provide some technical details that can be inclued in the email. 
+
+
+## Sending notification emails to tenants
 
 Use the [google group interface](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/?hl=en#!forum/gov-uk-paas-announce) to send the email.
 
@@ -25,171 +37,8 @@ Ex: "Incident with..."
 one way communication
 * Body: paste the content of the reviewed draft. You may have to adjust formatting.
 
-## Templates
 
-In general you can follow this basic format:
-
-* What we are doing
-* Why we are doing it
-* How it affects/benefits the Tenant and their users 
-* Action the user needs to take
-
-The equivalent for incidents would be:
-
-* What is happening (that we know)
-* What we are doing
-* Any action the user should take (or things we know they *shouldn't* do)
-
-
-### We're having an incident email template
-
-####   Email subject
-
-This should start with ‘IMPORTANT:’
- 
-_[If possible, be specific about what the problem is or the problem that the end user might be experiencing, ie:]_ 
- 
-* IMPORTANT: problem accessing the GOV.UK PaaS API
-* IMPORTANT: problem affecting GOV.UK PaaS applications
-* IMPORTANT: GOV.UK PaaS outage
- 
-_[If it’s not possible to be specific or we don’t know what the cause/effect is, use:]_
- 
-* IMPORTANT: problem with GOV.UK PaaS
-
-####   Email body
-
-We are aware of and investigating a problem with GOV.UK PaaS.
- 
-_[Where known, explain what we know about what the issue is and how it affects Tenants and their users. For the latter, you could use:]_
-
-* Your users can’t access your service
-* Your website/service is down and unavailable to your users
-* Some user requests may fail
-* Your users can only access your service intermittently
-* [API down] ...which means you can’t update/access your service
-* You won’t be able to access your applications
-* You’re not receiving any metrics for your service
-* You’re receiving a high number of error messages
-* You’re experience high error rates
-
- 
-_[If applicable, summarise any action Tenants should or shouldn’t take.]_
- 
-We’re looking into this as a matter of urgency and will update you as soon as we know more. 
- 
-Regards,
- 
-_[Name and role of person handling incident comms]_ 
-
-GOV.UK PaaS team
-
-
-
-### Update during an incident email template
-
-####   Email subject
-
-UPDATE: _[This should duplicate the content of the first incident notification email subject - unless this wasn’t specific, in which case we should amend it to say what the problem is, ie:]_
-
-* UPDATE: problem accessing the GOV.UK PaaS API
-* UPDATE: problem affecting GOV.UK production applications
-
-####   Email body
-
-We are actively working on the issue of _[summarise problem that was established in the first notification email.]_
-
-We have _[explain **what we’ve done** to investigate and **what steps we’ve taken** so far to resolve the issue.]_
-
-_[If relevant, describe any:_
- 
-* _action users should take_ 
-* _action users shouldn’t take_
-* _workarounds that would help users]_
-
-Fixing this issue is our priority - we know that this has impacted on the service you provide and we’re doing everything we can to resolve it as quickly as possible. 
- 
-We’ll continue to update you as we know more, and we’ll let you know as soon as the problem has been resolved.
- 
-We’re sorry for the inconvenience that this has caused to your users and your team. 
- 
-If you need to contact us for help or anything else, please email us via gov-uk-paas-support@digital.cabinet-office.gov.uk 
-
-Regards,
-
-_[Name and role of person handling incident comms]_
-
-GOV.UK PaaS team
-
-
-### Further updates during an incident email template
-
-####   Email subject
-
-UPDATE: _[This should duplicate the content of the first update email subject]_.
-
-####   Email body
-
-Hello,
-
-We are still working to resolve the issue of _[summarise problem that was established in the first notification email.]_
-
-
-Since our last update, we have _[explain what we’ve done to a) investigate and b) resolve the issue since the last update email.]_
- 
-_[If relevant, describe any:_
- 
-* _new action users should take_ 
-* _new action users shouldn’t take_
-* _workarounds that would help users]_
- 
-We’ll continue to update you as we know more, and we’ll let you know as soon as the problem has been resolved.
- 
-Once again, we’re sorry for the inconvenience that this has caused to you and your users. 
- 
-If you need to contact us for help or anything else, please email us via gov-uk-paas-support@digital.cabinet-office.gov.uk
-
-Regards,
-
-_[Name and role of person handling incident comms]_
-
-GOV.UK PaaS team
-
-
-
-### We've resolved the incident email template
-
-####   Email subject
-
-RESOLVED: _[This should duplicate the content of the previous update email subject]_
- 
-####   Email body 
- 
-Hello,
- 
-We’ve resolved the issue that affected GOV.UK PaaS today, and full service has been restored to development and production applications running on the platform.
- 
-_[Describe what the issue was and how it affected Tenants and their users.]_
- 
-_[Describe the actions we took to fix the problem - there’s no need to include everything we tried or investigated, just the actions that led to us resolving the incident.]_
- 
-We’ll now start looking into why and how this happened. In the coming days, we’ll publish an incident report describing the timelines of the event, root cause of the problem, lessons we’ve learned and actions we’ll take to ensure it doesn’t happen again.  
- 
-I’m sorry for the impact that this has had on your users and the service you provide, and the problems this has caused for your team. 
- 
-_[If there’s an outage, add the following to the sentence above:]_
- 
-Making sure GOV.UK PaaS is constantly available and robust is our priority and we’ll be doing everything we can to minimise the possibility of outage in the future.
- 
-The quickest way to get help using the platform is to email us via gov-uk-paas-support@digital.cabinet-office.gov.uk.	To let us know how this incident has affected you, please contact the GOV.UK PaaS product managers: tom.dolan@digital.cabinet-office.gov.uk and jessica.o’leary@digital.cabinet-office.gov.uk. 
-
-Regards,
-	
-_[Name and role of person handling incident comms]_
-
-GOV.UK PaaS team
-
-### CF upgrade
+### CF upgrade email template
 
 Subject (ex): GOV.UK PaaS - Cloud Foundry changes - 17th March 2017
 
@@ -199,3 +48,6 @@ The body should contain:
  - Downtime or service impact if any
  - Summary of buildpack changes. In order to retrieve the buildpack notes, you can use the script:
 `paas-cf/scripts/generate_buildpack_release_notes.sh`
+
+
+**NB Incident comms email templates are saved in Statuspage.** 


### PR DESCRIPTION
## What

Changed docs to show that we now use Statuspage.io to send incident comms. This changes is in the [If you're incident comms:](https://government-paas-team-manual.readthedocs.io/en/latest/support/support_manual/#if-youre-incident-comms) section. 

Also edited the [Notifying Tenants](https://government-paas-team-manual.readthedocs.io/en/latest/team/notifying_tenants/)  section of the team manual to highlight the fact that we have two separate comms channels: one for incident (Statuspage) and one for updates and new features (Google group)>

## How to review

Read the above sections of the team manual.