### PR TITLE
[#145682111] Remove UAA SSO workaround guidance

### DIFF
--- a/docs/guides/cf_admin_users.md
+++ b/docs/guides/cf_admin_users.md
@@ -6,17 +6,3 @@ able to attribute actions to individuals.
 In order to ensure two factor authentication is used, we use our google apps accounts to authenticate:
 
 `cf login -a api.SYSTEM_DOMAIN --sso`
-
-At present, a [bug](https://github.com/cloudfoundry/uaa/issues/562) in UAA means that you will see an error like this:
-
-![Screenshot showing invalid redirect_uri error from google](https://camo.githubusercontent.com/4df4a3816727d2d6376df5d8bfe0f416446e22ae/68747470733a2f2f692e696d6775722e636f6d2f543268777076752e706e67)
-
-to fix this, edit the `redirect_uri` url parameter, which has had the login server hostname removed from it.
-
-Change it from:
-
-`redirect_uri=https%3A%2F%2Flogin%2Fcallback%2Fgoogle`
-
-to
-
-`redirect_uri=https%3A%2F%2Flogin.SYSTEM_DOMAIN%2Flogin%2Fcallback%2Fgoogle`


### PR DESCRIPTION
## What

This is no longer necessary now that we are using uaa-release v41.

## How to review

Review in conjunction with https://github.com/alphagov/paas-cf/pull/971

Wait until https://github.com/alphagov/paas-cf/pull/971 is merged and deployed to CI and try to log into CI with your user account. Don't bother trying to test it in dev because it is a faff.

## Who

Only those with a CF admin user account associated with their GDS email address.