### PR TITLE
[#145672449] Update link to credentials repo

### DIFF
--- a/docs/team/orientation.md
+++ b/docs/team/orientation.md
@@ -17,8 +17,7 @@ depend on, but this list should be enough to get you started.
 
 - [alphagov/paas-cf](https://github.com/alphagov/paas-cf)
 - [alphagov/paas-team-manual](https://github.com/alphagov/paas-team-manual)
-- [government-paas/credentials](https://github.digital.cabinet-office.gov.uk/government-paas/credentials)
-  (internal only)
+- [alphagov/paas-credentials](https://github.com/alphagov/paas-credentials) (private)
 
 # Accounts
 


### PR DESCRIPTION
## What

Update link to credentials repo

It has been moved to GitHub.com

## How to review

1. Check the new link works.
1. Check that I have't missed any other links.

## Who can review

Anyone.