### PR TITLE
Update standup time to be 9:45am

### DIFF
--- a/docs/team/orientation.md
+++ b/docs/team/orientation.md
@@ -32,7 +32,7 @@ list and their respective URLs in the following spreadsheet:
 These are key events that happen each fortnightly sprint. You'll get
 calendar invites that detail the actual times and locations.
 
-- Stand-up is at 09:30 every morning. We'll talk briefly about progress,
+- Stand-up is at 09:45 every morning. We'll talk briefly about progress,
 blockers, and pair rotation. Please be on time and keep it succinct. There
 is time for more detailed conversations immediately afterwards.
 - Planning is at the beginning of a sprint. Most of the stories


### PR DESCRIPTION
Standup has been at 9:45am for at least 4 weeks (since I started.) The manual still says it is at 9:30am and this corrects the time.