### PR TITLE
[#145189815] New guide to connecting to Concourse and BOSH

### DIFF
--- a/docs/guides/Connecting_to_Concourse_and_BOSH.md
+++ b/docs/guides/Connecting_to_Concourse_and_BOSH.md
@@ -1,0 +1,128 @@
+## SSH into the Concourse VM
+
+We can SSH directly into the Concourse VM using a Makefile target in `paas-cf`. This copies the Concourse VM's SSH key from a state bucket on S3, prints the VM's sudo password, and makes the SSH connection.
+
+```
+make ssh_concourse
+```
+
+---
+
+## Connecting bosh_cli to BOSH
+
+### Primary solution: use a Concourse task
+
+A Makefile task in `paas-cf` connects you to a one-off task in concourse that's already logged into bosh and has the deployment set using the CF manifest:
+
+```
+make dev bosh-cli
+```
+
+### Backup solution: tunnel BOSH commands through SSH
+
+If you can't use the task on Concourse, you can tunnel local `bosh` commands to the deployment's BOSH. 
+
+1. First install `bosh` with `gem install bosh_cli`.
+2. Second [establish an SSH connection to the BOSH VM](#ssh-into-the-bosh-vm).
+3. Third use the script below to forward the BOSH port, log you into BOSH and and drop you into a `bash` session to run `bosh` commands:
+
+```bash
+#!/bin/bash
+
+set -eu
+
+trap 'make dev stop-tunnel; rm -f /tmp/manifest.yml' EXIT
+
+echo "Making SSH tunnel to Bosh..."
+make dev tunnel TUNNEL=25555:10.0.0.6:25555
+
+echo
+echo "Logging into and targeting Bosh..."
+BOSH_PASSWORD=$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | awk '/bosh_admin_password/ {print $2}')
+bosh login admin "$BOSH_PASSWORD"
+bosh target localhost
+
+echo
+echo "Downloading CloudFoundry manifest..."
+aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/cf-manifest.yml" /tmp/manifest.yml
+bosh deployment /tmp/manifest.yml
+
+echo
+echo "You are now in a local shell"
+echo "The bosh CLI is logged into the remote BOSH"
+echo "Run bosh commands such as: bosh vms"
+bash
+```
+
+Alternatively you can append `-L 25555:localhost:25555` to the SSH commands in order to establish the tunnel, and login to BOSH manually.
+
+---
+
+## SSH into the BOSH VM
+
+### Primary solution: tunnel through the Concourse VM
+
+In ordinary circumstances we use the Concourse VM as a gateway to access the BOSH VM. There is a Makefile task in `paas-cf` to establish this SSH connection.  This copies SSH keys for the Concourse and BOSH VMs from a state bucket on S3, prints the BOSH VM's sudo password, and makes the SSH connection.
+
+```
+make ssh_bosh
+```
+
+### Backup method: tunneling through a new VM
+
+Should the Concourse VM be overloaded or missing, we can create a new EC2 instance and use it as a gateway to the BOSH VM.
+
+Go into EC2 and create a new VM:
+
+* It must be on the VPC network of your deployment.
+* It may need to be on an `infra` subnet.
+* It must be assigned a public IP.
+* It must have both the `office-access-ssh` and `bosh-ssh-client` security groups. This gives SSH access from the GDS Office and SSH access to the BOSH VM.
+* It must use the `${DEPLOY_ENV}_key_pair` key pair for the script below to work.
+
+Use the script below to SSH into the BOSH VM using this new VM as a gateway. You must first define the new VM's public IPv4 address as a `VM_IP` environment variable, for instance `VM_IP=53.33.78.122`.
+
+```
+BOSH_KEY=/tmp/bosh_id_rsa.$RANDOM
+DEPLOY_KEY=/tmp/deploy_id_rsa.$RANDOM
+trap 'rm -f ${BOSH_KEY} ${DEPLOY_KEY}' EXIT
+aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh_id_rsa" ${BOSH_KEY} && chmod 400 ${BOSH_KEY}
+aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/id_rsa" ${DEPLOY_KEY} && chmod 400 ${DEPLOY_KEY}
+
+BOSH_IP=10.0.0.6
+echo
+aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | \
+  ruby -ryaml -e 'puts "Sudo password is " + YAML.load(STDIN)["secrets"]["bosh_vcap_password_orig"]'
+echo
+
+SSH_OPTIONS='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=60'
+PROXY_COMMAND="ssh ${SSH_OPTIONS} -i ${DEPLOY_KEY} ec2-user@${VM_IP} -W ${BOSH_IP}:22"
+ssh ${SSH_OPTIONS} -o ProxyCommand="${PROXY_COMMAND}" -i ${BOSH_KEY} vcap@${BOSH_IP}
+``` 
+
+You should terminate the new VM once you're done.
+
+### Emergency method: connecting directly to BOSH
+
+If the Concourse VM is unavailable and creating new VMs is impossible or would take too long, you can make the BOSH VM accessible to our IP addresses. This should be a last-resort and temporary measure.
+
+Go into EC2 and add the `bosh/0` VM to the `office-access-ssh` security group. You should now be able to SSH to its public IP address using this script:
+
+```
+BOSH_KEY=/tmp/bosh_id_rsa.$RANDOM
+trap 'rm -f ${BOSH_KEY}' EXIT
+aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh_id_rsa" ${BOSH_KEY} && chmod 400 ${BOSH_KEY}
+
+BOSH_IP=$(aws ec2 describe-instances \
+              --filters 'Name=tag:Name,Values=*' "Name=key-name,Values=${DEPLOY_ENV}_bosh_ssh_key_pair" \
+              --query 'Reservations[].Instances[].PublicIpAddress' --output text)
+echo
+aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | \
+  ruby -ryaml -e 'puts "Sudo password is " + YAML.load(STDIN)["secrets"]["bosh_vcap_password_orig"]'
+echo
+
+SSH_OPTIONS='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=60'
+ssh ${SSH_OPTIONS} -i ${BOSH_KEY} vcap@${BOSH_IP}
+```
+
+**Important: remove the `office-access-ssh` security group from `bosh/0` once you're done.**

--- a/docs/guides/Connecting_to_Concourse_and_BOSH.md
+++ b/docs/guides/Connecting_to_Concourse_and_BOSH.md
@@ -24,35 +24,7 @@ If you can't use the task on Concourse, you can tunnel local `bosh` commands to 
 
 1. First install `bosh` with `gem install bosh_cli`.
 2. Second [establish an SSH connection to the BOSH VM](#ssh-into-the-bosh-vm).
-3. Third use the script below to forward the BOSH port, log you into BOSH and and drop you into a `bash` session to run `bosh` commands:
-
-```bash
-#!/bin/bash
-
-set -eu
-
-trap 'make dev stop-tunnel; rm -f /tmp/manifest.yml' EXIT
-
-echo "Making SSH tunnel to Bosh..."
-make dev tunnel TUNNEL=25555:10.0.0.6:25555
-
-echo
-echo "Logging into and targeting Bosh..."
-BOSH_PASSWORD=$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | awk '/bosh_admin_password/ {print $2}')
-bosh login admin "$BOSH_PASSWORD"
-bosh target localhost
-
-echo
-echo "Downloading CloudFoundry manifest..."
-aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/cf-manifest.yml" /tmp/manifest.yml
-bosh deployment /tmp/manifest.yml
-
-echo
-echo "You are now in a local shell"
-echo "The bosh CLI is logged into the remote BOSH"
-echo "Run bosh commands such as: bosh vms"
-bash
-```
+3. Third run the `scripts/bosh_cli_tunnel.sh` script in `paas-cf`. This forwards the BOSH port, logs you into BOSH and and drops you into a `bash` session to run `bosh` commands:
 
 Alternatively you can append `-L 25555:localhost:25555` to the SSH commands in order to establish the tunnel, and login to BOSH manually.
 
@@ -80,25 +52,7 @@ Go into EC2 and create a new VM:
 * It must have both the `office-access-ssh` and `bosh-ssh-client` security groups. This gives SSH access from the GDS Office and SSH access to the BOSH VM.
 * It must use the `${DEPLOY_ENV}_key_pair` key pair for the script below to work.
 
-Use the script below to SSH into the BOSH VM using this new VM as a gateway. You must first define the new VM's public IPv4 address as a `VM_IP` environment variable, for instance `VM_IP=53.33.78.122`.
-
-```
-BOSH_KEY=/tmp/bosh_id_rsa.$RANDOM
-DEPLOY_KEY=/tmp/deploy_id_rsa.$RANDOM
-trap 'rm -f ${BOSH_KEY} ${DEPLOY_KEY}' EXIT
-aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh_id_rsa" ${BOSH_KEY} && chmod 400 ${BOSH_KEY}
-aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/id_rsa" ${DEPLOY_KEY} && chmod 400 ${DEPLOY_KEY}
-
-BOSH_IP=10.0.0.6
-echo
-aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | \
-  ruby -ryaml -e 'puts "Sudo password is " + YAML.load(STDIN)["secrets"]["bosh_vcap_password_orig"]'
-echo
-
-SSH_OPTIONS='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=60'
-PROXY_COMMAND="ssh ${SSH_OPTIONS} -i ${DEPLOY_KEY} ec2-user@${VM_IP} -W ${BOSH_IP}:22"
-ssh ${SSH_OPTIONS} -o ProxyCommand="${PROXY_COMMAND}" -i ${BOSH_KEY} vcap@${BOSH_IP}
-``` 
+Use the `scripts/ssh_bosh_temporary_gateway.sh` script in `paas-cf` to SSH into the BOSH VM using this new VM as a gateway. You must first define the new VM's public IPv4 address as a `VM_IP` environment variable, for instance `VM_IP=53.33.78.122`.
 
 You should terminate the new VM once you're done.
 
@@ -106,23 +60,6 @@ You should terminate the new VM once you're done.
 
 If the Concourse VM is unavailable and creating new VMs is impossible or would take too long, you can make the BOSH VM accessible to our IP addresses. This should be a last-resort and temporary measure.
 
-Go into EC2 and add the `bosh/0` VM to the `office-access-ssh` security group. You should now be able to SSH to its public IP address using this script:
-
-```
-BOSH_KEY=/tmp/bosh_id_rsa.$RANDOM
-trap 'rm -f ${BOSH_KEY}' EXIT
-aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh_id_rsa" ${BOSH_KEY} && chmod 400 ${BOSH_KEY}
-
-BOSH_IP=$(aws ec2 describe-instances \
-              --filters 'Name=tag:Name,Values=*' "Name=key-name,Values=${DEPLOY_ENV}_bosh_ssh_key_pair" \
-              --query 'Reservations[].Instances[].PublicIpAddress' --output text)
-echo
-aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | \
-  ruby -ryaml -e 'puts "Sudo password is " + YAML.load(STDIN)["secrets"]["bosh_vcap_password_orig"]'
-echo
-
-SSH_OPTIONS='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=60'
-ssh ${SSH_OPTIONS} -i ${BOSH_KEY} vcap@${BOSH_IP}
-```
+Go into EC2 and add the `bosh/0` VM to the `office-access-ssh` security group. You should now be able to SSH to its public IP address using the `scripts/ssh_bosh_expose_vm.sh` script in `paas-cf`.
 
 **Important: remove the `office-access-ssh` security group from `bosh/0` once you're done.**


### PR DESCRIPTION
## What

Ordinarily we run `bosh` commands from a task running in Concourse, using `paas-cf`'s `make bosh-cli`. We want instructions ready for connecting to BOSH if this approach doesn't work, for instance if we're shaking Concourse. Until now instructions like this have lived in the `paas-cf` `README.md` but it's grown unwieldy. 

This PR creates a guide in the team manual for connecting to BOSH, both for running `bosh` CLI commands and by SSH. The incidents cover a range of potential difficulties:

* How to SSH or bosh-cli if Concourse tasks are unusable
* How to SSH or bosh-cli if the Concourse VM is unusable
* How to SSH or bosh-cli if we cannot create new VMs

## How to review

* Perform the steps given in this new guide. Check you understand the instructions and they're effective in your environment. 
* If you think non-dev environments may behave differently, consider running some of these steps in a non-dev environment.

## Who can review

Not @46bit @henrytk @timmow 