### PR TITLE
[130899727] Add info about filtering gorouter logs

### DIFF
--- a/docs/support/finding_activity.md
+++ b/docs/support/finding_activity.md
@@ -85,6 +85,13 @@ It would imply that a new app has been created and staged.
 
 There may be times, where we'd need to be troubleshooting or reviewing an API Access logs. Here is a list, of more relevant and interesting points to be concerned about:
 
+## Gorouter
+
+In kibana, filtering the `@source.component` to `gorouter` will show the access logs. Request details are also parsed to allow searches like:
+
+- `NOT gorouter.status: 200`
+- `gorouter.method: POST`
+
 ## Router HAProxy
 
 In Kibana, you can look for the following phrases, to filter the access logs.


### PR DESCRIPTION
# What

We have enabled gorouter logs. This adds a short not to the manual about
which component name to search for and how to filter status codes.

Requires [paas-cf PR488](https://github.com/alphagov/paas-cf/pull/488/) to be deployed first.

# How to review

Proofread should be enough

# Who

Not @chrisfarms nor @samcrang 