### PR TITLE
Replace cell capacity planning method defined in ADR017

### DIFF
--- a/docs/architecture_decision_records/ADR017-cell-capacity-assignment.md
+++ b/docs/architecture_decision_records/ADR017-cell-capacity-assignment.md
@@ -1,7 +1,16 @@
+
+Superceded
+==========
+
+This has been superceded by [ADR021](/architecture_decision_records/ADR021-cell-capacity-assignment-2/) since November 2017. It has been retained for historical purposes.
+
+------------------------
+
+
 Context
 =======
 
-We want to ensure our platform remains available when a single AZ fails. This means that we need to have enough spare memory capacity left on cells to cover deploying apps from the failed zone. In case of 3 zones, that means each zone should be able to host 50% more apps (memory capacity wise). We can calculate maximum memory usable by all orgs by doing sum of their quotas. However, in practice much less memory is consumed. This is because
+-We want to ensure our platform remains available when a single AZ fails. This means that we need to have enough spare memory capacity left on cells to cover deploying apps from the failed zone. In case of 3 zones, that means each zone should be able to host 50% more apps (memory capacity wise). We can calculate maximum memory usable by all orgs by doing sum of their quotas. However, in practice much less memory is consumed. This is because-
 
 1. Org quotas come in T-shirt sizes and have considerable size jumps (e.g. 2, 10, 60 100G). You need to reserve next quota if previous one is too small for your needs, yet it doesn't mean you will be using all the capacity of the larger quota.
 1. App instance memory limits are set as upper memory consumption limit. Because of that, they tend to be set larger for safety. Actual app memory consumption is always lower, many times considerably.
@@ -24,7 +33,7 @@ We will maintain at least 50% of total org reserved capacity available when a zo
 Status
 ======
 
-Accepted
+Superceded by [ADR021](/architecture_decision_records/ADR021-cell-capacity-assignment-2/).
 
 Consequences
 ============

--- a/docs/architecture_decision_records/ADR021-cell-capacity-assignment-2.md
+++ b/docs/architecture_decision_records/ADR021-cell-capacity-assignment-2.md
@@ -57,10 +57,12 @@ From our data analysis (see context) the amount of memory consumed by apps
 can reach about 36% over a week-ago's smoothed average. We round up to 40% to
 include buffering/caching.
 
-We want to ensure that if an AZ fails, we have enough capacity remaining to
-host all our apps, with that 40% headroom.  This means that we'll want 1.4 x
-1.5 current usage. Which is about 2x actual memory consumed by processes on
-cells.
+If an AZ fails, we need enough capacity remaining to host all our apps. The
+failed AZ's apps are evenly divided amongst the surviving AZs. Because we have
+two remaining AZs, each surviving AZ will have 1.5x as many apps running.
+
+Because we want 40% headroom, we'll want 1.4 (headroom) x 1.5 (evacuated apps)
+current usage. This is about 2x actual memory consumed by processes on cells.
 
 Therefore we need to start alerting when the memory occupied by processes on
 cells is above 50%, when suitably smoothed to avoid noise / small spikes

--- a/docs/architecture_decision_records/ADR021-cell-capacity-assignment-2.md
+++ b/docs/architecture_decision_records/ADR021-cell-capacity-assignment-2.md
@@ -1,0 +1,107 @@
+Context
+=======
+
+We've been running with the cell provisioning policy in ADR017 since February.
+We haven't ever run out of cell capacity, but we've observed that there's
+excess capacity that we're paying for.
+
+At the time that we wrote ADR017 we had fewer tenants and an individual
+tenant's quota was a much greater proportion of total memory size. In other
+words a single tenant could conceivably use a greater proportion of our excess
+capacity.
+
+Cells are still deployed across 3 AZs.
+
+We still don't have a way to autoscale the number of cells to meet demand, so
+we need to ensure that we have surplus capacity for when we're not around.
+
+Cells are almost completely uncontended; we're not experiencing CPU or disk I/O
+contention and not all the cell memory is being used.
+
+Over the 3 month period from 1st August - 1st November
+
+- Usable memory (free + cached + buffered) is running between 77% and 92% of total cell memory
+- The maximum increase in memory usage over an exponentially smoothed average from a week previously was 36%
+- We're running at about 10% of our total container capacity
+- container usage has peaked at about 20% above the previous weeks
+- Average CPU usage is about 10%. We see daily peaks of 80%
+- reps think that about 50% of the capacity of cells is used
+- the largest amount that rep's allocated memory increased week on week was 55%
+
+
+Decision
+========
+
+Our objectives are:
+
+State | Expected behaviour
+------|-------------------
+All cells operational | Enough capacity to allow some but not all tenants to
+scale up to their full quota. The amount of excess capacity required should be
+enough to accommodate the fluctuations we can expect over a 3 day period
+(weekend + reaction time) While CF being deployed | As above: enough capacity
+to allow some tenants to scale up to their full quota One availability zone
+failed/degraded | Enough capacity to maintain steady state app usage. Not
+guaranteed to be able to scale apps up.  More than one AZ failed | The system
+is not expected to have sufficient capacity to host all running apps.
+
+To achieve this we need to start basing our capacity planning on current memory
+occupied by processes on cells, rather than the sum of all quotas given to
+users. We will define alerts for capacity planning purposes, the in-hours
+support person is expected to respond by adjusting the number of cells.
+
+We want to ensure that cells have at least 40% usable memory, above a smoothed
+average:
+- to allow buffering and caching to occur and not adversely impact application
+  performance
+- to allow some headroom for increases in the memory consumed by apps
+
+We want to ensure that if an AZ fails, we have enough capacity remaining to
+host all our apps, with that 40% headroom.  This means that we'll want 1.4 x
+1.5 current usage. Which is about 2x actual memory consumed by processes on
+cells.
+
+Therefore we need to start alerting when the memory occupied by processes on
+cells is above 50%, when suitably smoothed to avoid noise / small spikes
+causing frequent alarms.
+
+CPU usage is assumed to be a linear relation of memory usage and we will have a
+similar alert defined when it exceeds 50% on cells.
+
+In addition to wanting the cells to not run short on memory, we also want
+tenants to be able to scale apps up and down when all AZs are functional. In
+order to ensure this, we need to allow for a ~50% increase in requested memory,
+which means alerting when all the reps have a cumulative remaining capacity of
+~33%, when smoothed to avoid false alarms.
+
+We also need enough container capacity to allow tenants to scale apps up and
+down and deploy new apps. We should alert when we're using > 80% of the sum of
+our rep's container capacity. Again, this should be smoothed to ensure that
+short lived fluctuations in usage don't cause unnecessary alerts.
+
+It is likely that patterns such as the fluctuation in memory use over a week
+may change over time. We should review this decision after 6 months.
+
+Status
+========
+
+Proposed
+
+Consequences
+============
+
+We will alert on the following datadog metrics:
+- exponentially weighted moving average of `system.mem.pct_usable` averaged over cells < 0.5
+- smoothed system.cpu.idle averaged across cells < 50%
+- smoothed `cf.rep.ContainerCount / cf.rep.CapacityTotalContainers` cells of > 80%
+- smoothed `cf.rep.CapacityRemainingMemory / cf.rep.CapacityTotalMemory` of < 33%
+
+We will remove half the cells, but not all in one go. We should start by removing 1/4 of cells.
+
+After removing 1/4 of the cells, we should consider:
+- adjusting [rep's advertised memory
+  capacity](https://github.com/cloudfoundry/diego-release/blob/5f822ca91f9289de240924b90b6feabb06248ed8/jobs/rep/spec#L147)
+in order to allow overcommitment.
+- whether we should remove another 1/4 of the original capacity (1/3 of current capacity)
+
+We will save money.

--- a/docs/architecture_decision_records/ADR021-cell-capacity-assignment-2.md
+++ b/docs/architecture_decision_records/ADR021-cell-capacity-assignment-2.md
@@ -50,11 +50,15 @@ occupied by processes on cells, rather than the sum of all quotas given to
 users. We will define alerts for capacity planning purposes, the in-hours
 support person is expected to respond by adjusting the number of cells.
 
-We want to ensure that cells have at least 40% usable memory, above a smoothed
+We want to ensure that cells have some headroom above a smoothed
 average:
+- to allow some headroom for increases in the memory consumed by apps.
 - to allow buffering and caching to occur and not adversely impact application
-  performance
-- to allow some headroom for increases in the memory consumed by apps
+  performance.
+
+From our data analysis (see context) the amount of memory consumed by apps
+can reach about 36% over a week-ago's smoothed average. We round up to 40% to
+include buffering/caching.
 
 We want to ensure that if an AZ fails, we have enough capacity remaining to
 host all our apps, with that 40% headroom.  This means that we'll want 1.4 x

--- a/docs/architecture_decision_records/ADR021-cell-capacity-assignment-2.md
+++ b/docs/architecture_decision_records/ADR021-cell-capacity-assignment-2.md
@@ -96,7 +96,7 @@ Consequences
 We will alert on the following datadog metrics:
 
 - exponentially weighted moving average of `system.mem.pct_usable` averaged over cells < 50%
-- smoothed system.cpu.idle averaged across cells < 50%
+- smoothed `system.cpu.idle` averaged across cells < 50%
 - smoothed `cf.rep.ContainerCount / cf.rep.CapacityTotalContainers` cells of > 80%
 - smoothed `cf.rep.CapacityRemainingMemory / cf.rep.CapacityTotalMemory` of < 33%
 

--- a/docs/architecture_decision_records/ADR021-cell-capacity-assignment-2.md
+++ b/docs/architecture_decision_records/ADR021-cell-capacity-assignment-2.md
@@ -36,14 +36,10 @@ Our objectives are:
 
 State | Expected behaviour
 ------|-------------------
-All cells operational | Enough capacity to allow some but not all tenants to
-scale up to their full quota. The amount of excess capacity required should be
-enough to accommodate the fluctuations we can expect over a 3 day period
-(weekend + reaction time) While CF being deployed | As above: enough capacity
-to allow some tenants to scale up to their full quota One availability zone
-failed/degraded | Enough capacity to maintain steady state app usage. Not
-guaranteed to be able to scale apps up.  More than one AZ failed | The system
-is not expected to have sufficient capacity to host all running apps.
+All cells operational | Enough capacity to allow some but not all tenants to scale up to their full quota. The amount of excess capacity required should be enough to accommodate the fluctuations we can expect over a 3 day period (weekend + reaction time) 
+While CF being deployed | As above: enough capacity to allow some tenants to scale up to their full quota 
+One availability zone failed/degraded | Enough capacity to maintain steady state app usage. Not guaranteed to be able to scale apps up.  
+More than one AZ failed | The system is not expected to have sufficient capacity to host all running apps.
 
 To achieve this we need to start basing our capacity planning on current memory
 occupied by processes on cells, rather than the sum of all quotas given to
@@ -52,6 +48,7 @@ support person is expected to respond by adjusting the number of cells.
 
 We want to ensure that cells have some headroom above a smoothed
 average:
+
 - to allow some headroom for increases in the memory consumed by apps.
 - to allow buffering and caching to occur and not adversely impact application
   performance.
@@ -95,6 +92,7 @@ Consequences
 ============
 
 We will alert on the following datadog metrics:
+
 - exponentially weighted moving average of `system.mem.pct_usable` averaged over cells < 0.5
 - smoothed system.cpu.idle averaged across cells < 50%
 - smoothed `cf.rep.ContainerCount / cf.rep.CapacityTotalContainers` cells of > 80%

--- a/docs/architecture_decision_records/ADR021-cell-capacity-assignment-2.md
+++ b/docs/architecture_decision_records/ADR021-cell-capacity-assignment-2.md
@@ -77,7 +77,7 @@ which means alerting when all the reps have a cumulative remaining capacity of
 
 We also need enough container capacity to allow tenants to scale apps up and
 down and deploy new apps. We should alert when we're using > 80% of the sum of
-our rep's container capacity. Again, this should be smoothed to ensure that
+our reps' container capacity. Again, this should be smoothed to ensure that
 short lived fluctuations in usage don't cause unnecessary alerts.
 
 It is likely that patterns such as the fluctuation in memory use over a week

--- a/docs/architecture_decision_records/ADR021-cell-capacity-assignment-2.md
+++ b/docs/architecture_decision_records/ADR021-cell-capacity-assignment-2.md
@@ -93,7 +93,7 @@ Consequences
 
 We will alert on the following datadog metrics:
 
-- exponentially weighted moving average of `system.mem.pct_usable` averaged over cells < 0.5
+- exponentially weighted moving average of `system.mem.pct_usable` averaged over cells < 50%
 - smoothed system.cpu.idle averaged across cells < 50%
 - smoothed `cf.rep.ContainerCount / cf.rep.CapacityTotalContainers` cells of > 80%
 - smoothed `cf.rep.CapacityRemainingMemory / cf.rep.CapacityTotalMemory` of < 33%


### PR DESCRIPTION
## What

Replace ADR017 which has been very successful in ensuring that we didn't run out of capacity in the early days, but nowadays results in us over-provisioning infrastructure.

## How to review

- Have a look at the rationale and see if it makes sense
- Check my [numbers in Datadog](https://app.datadoghq.com/notebook/20341/Cell%20capacity%20November%202017)
- Think of sanity checks of your own 

## Who can review

Anyone but @bleach and @tomskerous 

