### PR TITLE
[#150711834] Update Bosh SSH instructions

### DIFF
--- a/docs/guides/Connecting_to_Concourse_and_BOSH.md
+++ b/docs/guides/Connecting_to_Concourse_and_BOSH.md
@@ -1,6 +1,6 @@
 ## SSH into the Concourse VM
 
-We can SSH directly into the Concourse VM using a Makefile target in `paas-cf`. This copies the Concourse VM's SSH key from a state bucket on S3, prints the VM's sudo password, and makes the SSH connection.
+We can SSH directly into the Concourse VM using a Makefile target in `paas-bootstrap`. This copies the Concourse VM's SSH key from a state bucket on S3, prints the VM's sudo password, and makes the SSH connection.
 
 ```
 make ssh_concourse
@@ -10,111 +10,43 @@ make ssh_concourse
 
 ## Connecting bosh_cli to BOSH
 
-### Primary solution: use a Concourse task
-
-A Makefile task in `paas-cf` connects you to a one-off task in Concourse that's already logged into BOSH and has the deployment set using the CF manifest:
+A Makefile task in `paas-bootstrap` pulls a Docker image and runs a container loaded with the secrets required to interact with Bosh using the CLI:
 
 ```
-make dev bosh-cli
+DEPLOY_ENV=foo make bosh-cli
 ```
 
-### Backup solution: tunnel BOSH commands through the Concourse VM
+The container will automatically login to and target Bosh. It will not select a deployment automatically, as you may want to target the Concourse deployment or Cloud Foundry. To target the deployment:
 
-If the Concourse VM is running but you can't use a Concourse task, you can still use the Concourse VM as a gateway to access the BOSH.
-
-`cd` into the `paas-cf` directory, save the below as a script and run it. This tunnels through the Concourse VM, SSH forwards the BOSH port to the BOSH VM, logs you into BOSH and and drops you into a `bash` session to run `bosh` commands:
-
-```bash
-#!/bin/bash
-
-set -eu
-
-trap 'make dev stop-tunnel; rm -f /tmp/manifest.yml' EXIT
-
-echo "Making SSH tunnel to Bosh..."
-make dev tunnel TUNNEL=25555:10.0.0.6:25555
-
-echo
-BOSH_PASSWORD=$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | awk '/bosh_admin_password/ {print $2}')
-bundle exec bosh -t localhost login admin -- "${BOSH_PASSWORD}"
-bundle exec bosh target localhost
-
-echo
-echo "Downloading CloudFoundry manifest..."
-aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/cf-manifest.yml" /tmp/manifest.yml
-bundle exec bosh deployment /tmp/manifest.yml
-
-echo
-echo "INSTRUCTIONS"
-echo "You are now in a local shell"
-echo "The bosh CLI is logged into the remote BOSH"
-echo "Use 'bundle exec bosh' as your BOSH CLI commands"
-echo "e.g., bundle exec bosh vms"
-bash
+```
+bosh download manifest <deployment> manifest.yml
+bosh deployment manifest.yml
 ```
 
-### Backup solution: forward BOSH commands directly to the BOSH VM
+#### Bosh SSH
 
-If the Concourse VM is down, you can achieve port forwarding by appending `-L 25555:localhost:25555` to SSH commands. See [the emergency instructions for SSHing into BOSH](#backup-method-connecting-directly-to-bosh).
+To SSH to Bosh-managed VMs you need to go via a gateway, as they aren't exposed publicly. We use the Bosh VM as the gateway. To avoid you having to set the gateway details manually we have a simple wrapper script for setting them for you. From inside the container you can run:
 
-### Using `bosh ssh`
+```
+bosh-ssh router/0
+```
 
-If using the backup solutions above, you have to specify a gateway when using `bosh ssh` commands. 
+Otherwise you have to set them manually:
 
-If you're SSHed through Concourse:
-
-1. Set its public IP as `CONCOURSE_IP`.
-2. Download the Concourse SSH key with: `aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/concourse_id_rsa" /tmp/concourse_id_rsa && chmod 400 /tmp/concourse_id_rsa`
-3. Append `--gateway_host "${CONCOURSE_IP}" --gateway_user vcap --gateway_identity_file /tmp/concourse_id_rsa` to `bosh ssh` commands.
-
-If you're SSHed directly into BOSH:
-
-1. Set its public IP as `BOSH_IP`.
-2. Download the BOSH SSH key with: `aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh_id_rsa" /tmp/bosh_id_rsa && chmod 400 /tmp/bosh_id_rsa`
-3. Append `--gateway_host "${BOSH_IP}" --gateway_user vcap --gateway_identity_file /tmp/bosh_id_rsa`to `bosh ssh` commands.
+```
+bosh ssh \
+  --gateway_host "$BOSH_IP" \
+  --gateway_user vcap \
+  --gateway_identity_file /tmp/bosh_id_rsa \
+  router/0
+```
 
 ---
 
 ## SSH into the BOSH VM
 
-### Primary solution: tunnel through the Concourse VM
-
-In ordinary circumstances we use the Concourse VM as a gateway to access the BOSH VM. There is a Makefile task in `paas-cf` to establish this SSH connection.  This copies SSH keys for the Concourse and BOSH VMs from a state bucket on S3, prints the BOSH VM's sudo password, and makes the SSH connection.
+There is a Makefile task in `paas-bootstrap` to establish this SSH connection.  This copies SSH keys for the BOSH VM from a state bucket on S3, prints the BOSH VM's sudo password, and makes the SSH connection.
 
 ```
 make ssh_bosh
 ```
-
-### Backup method: connecting directly to BOSH
-
-If the Concourse VM is unavailable and creating new VMs is impossible or would take too long, you can make the BOSH VM accessible to our IP addresses. This should be a last-resort and temporary measure.
-
-Go into the AWS Web Console. Go into EC2 and add the `office-access-ssh` Security Group to the `bosh/0` VM. See the below screenshot for where to find Security Group settings.
-
-![Screenshot of where to find Security Group settings in the AWS Web Console for EC2](../img/where-to-change-security-groups-on-an-ec2-instance.png)
-
-This change allows you to SSH into the BOSH VM from the Office or VPN. To do that, save the below as a script and run it.
-
-```bash
-#!/bin/bash
-
-BOSH_KEY=/tmp/bosh_id_rsa.$RANDOM
-trap 'rm -f ${BOSH_KEY}' EXIT
-aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh_id_rsa" ${BOSH_KEY} && chmod 400 ${BOSH_KEY}
-
-BOSH_IP=$(aws ec2 describe-instances \
-              --filters 'Name=tag:Name,Values=*' "Name=key-name,Values=${DEPLOY_ENV}_bosh_ssh_key_pair" \
-              --query 'Reservations[].Instances[].PublicIpAddress' --output text)
-echo
-aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | \
-  ruby -ryaml -e 'puts "Sudo password is " + YAML.load(STDIN)["secrets"]["bosh_vcap_password_orig"]'
-echo
-
-SSH_OPTIONS='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=60'
-# shellcheck disable=SC2086
-ssh ${SSH_OPTIONS} -i "${BOSH_KEY}" vcap@"${BOSH_IP}"
-```
-
-**Important: remove the `office-access-ssh` security group from `bosh/0` once you're done.**
-
-If you want to use the BOSH CLI, append `-L 25555:localhost:25555` to the final SSH command and then target the CLI at `localhost`.

--- a/docs/guides/IPSec_debugging.md
+++ b/docs/guides/IPSec_debugging.md
@@ -1,7 +1,7 @@
 ## IPSec debugging
 
 
-There may be a need, to debug the IPSec on our machines. In order to do that, you may want to log into `bosh-cli` and then `bosh ssh {router|cell}`.
+There may be a need, to debug the IPSec on our machines. In order to do that, you may want to log into the routers or cells. See [Connecting bosh_cli to Bosh](Connecting_to_Concourse_and_BOSH/#connecting-bosh_cli-to-bosh) for instructions.
 
 ### Fiddle with the logging level
 

--- a/docs/guides/Restoring_the_CF_databases.md
+++ b/docs/guides/Restoring_the_CF_databases.md
@@ -48,8 +48,8 @@ Below are some generic instructions on restoring the CF RDS instance databases o
 **2.** Create a tunnel to the backup via Concourse:
 
 ```
-# CHANGEME to your paas-cf directory
-cd /path/to/paas-cf
+# CHANGEME to your paas-bootstrap directory
+cd /path/to/paas-bootstrap
 
 # CHANGEME to the endpoint (hostname) of the RDS instance you
 # are restoring from. This can be found in the AWS console.

--- a/docs/support/responding_to_alerts.md
+++ b/docs/support/responding_to_alerts.md
@@ -39,7 +39,7 @@ get this information you will need to SSH to any Cloud Foundry VM and query
 the endpoint yourself:
 
 ```
-/tmp/build/04dcec6b # bosh ssh api/0
+bash# bosh-ssh api/0
 …
 api/00673a4a-b11f-410d-a037-34d56a3e2e71:~$ curl -i https://cdn-broker.<SYSTEM_DOMAIN>/healthcheck
 HTTP/1.1 500 Internal Server Error
@@ -99,8 +99,10 @@ solution to restoring the platform was to restart both instances one after the
 other.
 
 ```sh
-cd ${PAAS_CF_DIR}
-make prod bosh-cli
+cd ${PAAS_BOOTSTRAP_DIR}
+DEPLOY_ENV=prod make bosh-cli
+bosh download manifest prod manifest.yml
+bosh deployment manifest.yml
 bosh restart uaa # You may want/need to target an instance instead uaa/0, uaa/1
 ```
 
@@ -108,9 +110,9 @@ There may be different reasons for the latency to drop down on any of the VMs.
 We found out the issue by logging into the VM itself and dig through the logs.
 
 ```sh
-cd ${PAAS_CF_DIR}
-make prod bosh-cli
-bosh ssh uaa
+cd ${PAAS_BOOTSTRAP_DIR}
+DEPLOY_ENV=prod make bosh-cli
+bosh-ssh uaa/0
 tail -1000 /var/vcap/sys/log/uaa/uaa.log
 ```
 


### PR DESCRIPTION
## What

We now SSH to Bosh directly, so we can remove all instructions relating
to going via Concourse. We remove all of the backup options, because if
the Bosh VM isn't available then we have bigger problems than how to
use the Bosh CLI.

## How to review

Review in conjunction with https://github.com/alphagov/paas-bootstrap/pull/100 and https://github.com/alphagov/paas-cf/pull/1100
Probably best to merge this after those ones, as things could change as a result of the review.

* check it is accurate
* check it reads most goodly, with grammar correctly and stuff.
* run it locally using instructions in the README. Check it looks okay and functions properly.
* preferably run all instructions that have changed to see they still work.

## Who

Anyone but me or @camelpunch 
