### PR TITLE
[#152543946]: Remove references to Nginx in front of UAA

### DIFF
--- a/docs/support/finding_activity.md
+++ b/docs/support/finding_activity.md
@@ -101,12 +101,11 @@ In Kibana, you can look for the following phrases, to filter the access logs.
 - `haproxy.http_request_verb: POST`
 - `haproxy.time_backend_response: >7`
 
-## NGINX
+## Cloud Controller
 
-It's probably worth to mention, that there is a `@source.component` which could help you investigate more specific access logs. For instance:
+Nginx runs on the same VM as Cloud Controller, so you can filter with:
 
-- `vcap_nginx_access` - Logs obtained from Cloud Controller's nginx setup.
-- `uaa_nginx_access` - Logs obtained from the UAA traffic.
+- `@source.component:vcap_nginx_access`
 
 ### UAA audit log in detail
 


### PR DESCRIPTION
## What

We are removing Nginx now that UAA is behind gorouter and the endpoint
blocking can be done within UAA.

We no longer have access logs from the UAA VMs in Logsearch. We do have
access logs from gorouter, which will help us to see traffic but not
necessarily diagnose inter-VM problems.

I've confirmed that the `uaa.audit.remote_address` in UAA's audit logs still
has the correct IP from `X-Forwarded-For`.

## How to review

Review with alphagov/paas-cf#1104 and confirm that the changes make sense.

## Who can review

Not @dcarley or @bandesz.