### PR TITLE
Add how to for enabling Github oAuth in dev

### DIFF
--- a/docs/guides/Github_oAuth_in-Dev.md
+++ b/docs/guides/Github_oAuth_in-Dev.md
@@ -1,0 +1,15 @@
+How to enable Github oAuth for your dev environments
+
+This will enable anyone on the team to be able to log into your concourse
+
+ - Create an [oAuth application](https://github.com/settings/applications/new)
+ - Set your homepage URL to `https://deployer.<your env>.dev.cloudpipeline.digital`
+ - Authorization callback URL should be `https://deployer.<your env>.dev.cloudpipeline.digital/auth/github/callback`
+ - Store the client ID and Client secret in your personal pass store under the following locations `github.com/concourse/dev/client_id` and `github.com/concourse/dev/client_secret`
+ - Run `make dev upload-github-oauth GITHUB_PASSWORD_STORE_DIR=<your pass dir> DEPLOY_ENV=<your env>`
+ - Checkout Master and push the pipeline with the following command for deployer concourse
+```
+BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev deployer-concourse pipelines SELF_UPDATE_PIPELINE=false ENABLE_GITHUB=true
+```
+ - Run the `create-bosh-concourse` pipeline
+ - once it has completed, login to team main using the login with Github button.


### PR DESCRIPTION
## What

This commit adds a guide for how to enable Github oAuth in dev
environments. This method is not currently the default authentication
mechanism.

## How to test

Code review
Pull this branch and run `pip install -Ur requirements.txt` followed by `mkdocs serve` visit http://127.0.0.1:8000
Test the how to guide

## Who can review

Not @LeePorte