### PR TITLE
Instructions for responding to ELB node failures

### DIFF
--- a/docs/support/responding_to_alerts.md
+++ b/docs/support/responding_to_alerts.md
@@ -123,3 +123,24 @@ solution was to upgrade UAA release on its own.
 Read more in the
 [UAA Downtime investigation](https://www.pivotaltracker.com/n/projects/1275640/stories/151808174)
 story.
+
+## Intermittent ELB failures
+
+Users have previously experienced intermittent request timeouts and errors when
+accessing their apps. During a particular incident, we believe that requests
+timed out due to ELB node failures.
+
+We publish two metrics:
+
+1. `aws.elb.unhealthy_node_count` - number of IPs that failed to respond to an HTTP request
+1. `aws.elb.healthy_node_count`   - number of IPs that responded as expected
+
+Details of the monitoring approach can be found in
+[the README for our monitoring application](https://github.com/alphagov/paas-cf/blob/master/tools/metrics/README.md).
+
+We have been advised by AWS that if we believe we are experiencing an issue
+with one or more ELB nodes that we should raise a "high priority" support
+ticket with them.
+
+Read more in the
+[Incident Report](https://docs.google.com/document/d/1XUH42lgt86q2XGZY1uosb0M44vtnpeyREDJlyfxs72w/edit#heading=h.bac2cwm6xa89).

--- a/docs/support/responding_to_alerts.md
+++ b/docs/support/responding_to_alerts.md
@@ -142,5 +142,25 @@ We have been advised by AWS that if we believe we are experiencing an issue
 with one or more ELB nodes that we should raise a "high priority" support
 ticket with them.
 
+To obtain the IP address of the failing node(s), you should inspect the logs of
+the paas-metrics app. This is deployed to the 'monitoring' space of the 'admin'
+org. You should see logs such as:
+
+```
+2017-12-01T14:14:09.68+0000 [APP/PROC/WEB/0] OUT
+{
+    "timestamp":"1512137649.686135292",
+    "source":"metrics",
+    "message":"metrics.elb-node-failure",
+    "log_level":1,
+    "data":{
+        "addr":"52.31.169.122:443",        <-- this is the ELB node IP
+        "err":"bad error happened!",
+        "start":"2017-12-01T14:14:09.679602987Z",
+        "stop":"2017-12-01T14:14:09.679602987Z"
+    }
+}
+```
+
 Read more in the
 [Incident Report](https://docs.google.com/document/d/1XUH42lgt86q2XGZY1uosb0M44vtnpeyREDJlyfxs72w/edit#heading=h.bac2cwm6xa89).


### PR DESCRIPTION
## What

Add information to the manual to help support folk deal with intermittent ELB node failures.

## How to review

Read it, try the links, check that the Datadog link would work (see corresponding [PR in paas-cf](https://github.com/alphagov/paas-cf/pull/1127)).

## Who can review

Not @chrisfarms or @camelpunch