### PR TITLE
Update ARD015 now that AWS support encrypted t2 RDS instances.

### DIFF
--- a/docs/architecture_decision_records/ADR015-rds-storage-encryption-plans.md
+++ b/docs/architecture_decision_records/ADR015-rds-storage-encryption-plans.md
@@ -8,7 +8,8 @@ of the tenants databases created by our [RDS broker](https://github.com/alphagov
 But there are [some limitations](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encryption.html#Overview.Encryption.Limitations):
 
  * Storage Encryption can only be enabled on creation of the DB. There is no way to update an instance to enable or disable encryption. The only way is by creating a encrypted (or unencrypted) copy of a snapshot, to then restore it to a DB instance.
- * Storage Encryption is only supported [for some instance types](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encryption.html#d0e47573). Specifically it is not supported for `db.t2.small` and `db.t2.micro.`, used in our Small and Free plans.
+ * <s>Storage Encryption is only supported [for some instance types](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encryption.html#d0e47573). Specifically it is not supported for `db.t2.small` and `db.t2.micro.`, used in our Small and Free plans</s>
+ * **Update 2018-01-24:** Amazon have now [enabled support for encryption of `t2` instances](https://aws.amazon.com/about-aws/whats-new/2017/06/amazon-rds-enables-encryption-at-rest-for-additional-t2-instance-types/).
 
 In consequence:
 

--- a/docs/architecture_decision_records/ADR015-rds-storage-encryption-plans.md
+++ b/docs/architecture_decision_records/ADR015-rds-storage-encryption-plans.md
@@ -20,17 +20,17 @@ In consequence:
 We have 3 options to proceed:
 
  1. Enable Encryption in the Medium and Large plans, and document the restrictions.
-  * Less effort to implement.
-  * We might end having unencrypted database in a plan that is meant to be encrypted, which is confusing for the users and operators.
-  * Existing Instances will remain unencrypted.
+    * Less effort to implement.
+    * We might end having unencrypted database in a plan that is meant to be encrypted, which is confusing for the users and operators.
+    * Existing Instances will remain unencrypted.
  2. Change the instance type for the Small plan to `db.m3.medium`.
-  * Would allow migrate from Small to Medium or Large.
-  * We will still have the problem for the Free plan.
-  * Increases the costs for the Small plan (double).
+    * Would allow migrate from Small to Medium or Large.
+    * We will still have the problem for the Free plan.
+    * Increases the costs for the Small plan (double).
  3. Provide additional explicit plans with Encryption enabled, and keep the old ones. Add logic to prevent updates between plans with or without encryption.
-  * It would be more explicit and clear, and the plan would match the state of the existing database.
-  * Existing instances would still match with the plan description.
-  * We will add more plans, which makes it more confusing for the tenants.
+    * It would be more explicit and clear, and the plan would match the state of the existing database.
+    * Existing instances would still match with the plan description.
+    * We will add more plans, which makes it more confusing for the tenants.
 
 
 Decision


### PR DESCRIPTION
## What

AWS have [enabled encryption support for t2 instances](https://aws.amazon.com/about-aws/whats-new/2017/06/amazon-rds-enables-encryption-at-rest-for-additional-t2-instance-types/) since this ADR was written. This therefore adds an update making this clear.

I've also fixed some a formatting issue.

## How to review

Run the docs locally as described in the README. Verify this looks correct.

## Who can review

Not me.