### PR TITLE
[#134014357] Replace @source.name with @source.id

### DIFF
--- a/docs/support/finding_activity.md
+++ b/docs/support/finding_activity.md
@@ -47,8 +47,8 @@ individual to go further.
 Once you found something interesting above, you could use it to refine
 your search to get deeper. For instance, one of the logs above, would have:
 
-- `@source.name` - Defining the VM we'd need to access. For example:
-  `api/0`
+- `@source.id` - Defining the VM we'd need to access. For example:
+  `4556706c-0e04-401e-bbc5-d0933e98f892`
 - `@message` consisting of `vcap-request-id`
 
 If you search for `"{VCAP_REQUEST_ID}"` in Kibana, you should get


### PR DESCRIPTION
## What

After updating the syslog-release the @source.name field will only contain the BOSH job name. You can identify the VM with the @source.id field which contains the VM id.

## How to review

Read it.

## Who can review it

Not @LeePorte or @bandesz