### PR TITLE
[#154769249] References to cf-release become cf-deployment

### DIFF
--- a/docs/guides/upgrading_CF,_bosh_and_stemcells.md
+++ b/docs/guides/upgrading_CF,_bosh_and_stemcells.md
@@ -34,10 +34,9 @@ You should test the upgrade changeset:
 
 ### Buildpacks
 
-You should upgrade the buildpacks to at least the versions included in the new cf-deployment version.
+**Note**: We have to a give at least a week's notice to tenants about the buildpack upgrades, so prepare the version changes separately from the CF component upgrades.
 
-**Note**: We use separate releases for the buildpacks to make it easier to
-upgrade them in future without upgrading the whole of CF.
+You should upgrade the buildpacks to at least the versions included in the new cf-deployment version.
 
 ## Notify the tenants
 

--- a/docs/guides/upgrading_CF,_bosh_and_stemcells.md
+++ b/docs/guides/upgrading_CF,_bosh_and_stemcells.md
@@ -16,6 +16,8 @@
 ```
 git diff v1.0.0...v1.14.0 cf-deployment.yml
 ```
+* Update the cf-smoke-tests resource in the pipeline to use a new branch of our fork that has the latest changes from upstream master.
+* Update the cf-acceptance-tests resource in the pipeline to use an upstream `cfX.Y` branch matching the cf-deployment version.
 
 ## Doing the upgrade
 

--- a/docs/guides/upgrading_CF,_bosh_and_stemcells.md
+++ b/docs/guides/upgrading_CF,_bosh_and_stemcells.md
@@ -2,8 +2,8 @@
 
 * Separate the upgrade of Cloud Foundry and stemcells from the upgrade of Bosh. Upgrades can cause problems and our experience is that it is difficult to be certain about the cause of those problems if multiple things have changed.
 * Establish the correct version to upgrade to. This will usually be the latest stable release, or the one before it, subject to review. The main driver for not always picking the latest release is to avoid the bad releases which CF produce from time to time. An alternative strategy may be to pick a release at least one week old, thereby giving Pivotal time to flag and pull bad releases before we plough ahead with them. Kick-off is an appropriate place for this review.
-* Check [cf-release releases documentation](https://github.com/cloudfoundry/cf-release/releases) before upgrading to a particular version. There have been versions, such as [v232](https://github.com/cloudfoundry/cf-release/releases/tag/v232), where the release is not appropriate for production usage.
-* Refer to cf-release documentation for recommended versions of all related releases (for example, Diego and related components). Read the documentation for every release of all of these components. It will save you time and pain in the long run.
+* Check [cf-deployment releases documentation](https://github.com/cloudfoundry/cf-deployment/releases) before upgrading to a particular version. There have been releases that became inappropriate for production usage.
+* Refer to cf-deployment documentation for recommended versions of all related releases (for example, Diego and related components). Read the documentation for every release of all of these components. It will save you time and pain in the long run.
 * Check the [diego release documentation](https://github.com/cloudfoundry-incubator/diego-release/releases)
 * Check the [etcd release documentation](https://github.com/cloudfoundry-incubator/etcd-release/releases)
 * Check the [consul release documentation](https://github.com/cloudfoundry-incubator/consul-release/releases)
@@ -11,11 +11,10 @@
 * Check the [bosh release documentation](https://github.com/cloudfoundry/bosh/releases)
 * Check the [stemcell release documentation](http://bosh.cloudfoundry.org/stemcells/)
 * Check the [stack release documentation](https://github.com/cloudfoundry/cflinuxfs2-release/releases)
-* These releases may already be included in the main cf-release. Review if it makes sense to still use the separate release or switch to the standard one from cf-release instead.
 * Check the job ordering in the [Diego manifest](https://github.com/cloudfoundry/diego-release/blob/develop/manifest-generation/diego.yml) to see if our job ordering needs to change as well.
-* Use `git diff` in the `cf-release` repo to see example changes to the manifest templates. For example, to see differences between v228 and v233:
+* Use `git diff` or GitHub compare in the `cf-deployment` repo to see example changes to the manifest. For example, to see differences between v1.0.0 and v1.14.0:
 ```
-git diff --exit-code -U5 --patience v228...v233 templates
+git diff v1.0.0...v1.14.0 cf-deployment.yml
 ```
 
 ## Doing the upgrade
@@ -25,7 +24,7 @@ You should test the upgrade changeset:
 * From a fully deployed master with Datadog enabled, equivalent to the change that will happen in
   in production.
 * Deploying a fresh CF, which is something we frequently do in our
-  development environments after the autodelete-cloufoundry pipeline
+  development environments after the autodelete-cloudfoundry pipeline
   runs overnight.
 * Confirm that [rotating credentials](../team/rotating_credentials.md) still
   works and doesn't cause additional downtime during deployments.
@@ -33,7 +32,7 @@ You should test the upgrade changeset:
 
 ### Buildpacks
 
-You should upgrade the buildpacks to at least the versions included in the new cf-release version.
+You should upgrade the buildpacks to at least the versions included in the new cf-deployment version.
 
 **Note**: We use separate releases for the buildpacks to make it easier to
 upgrade them in future without upgrading the whole of CF.


### PR DESCRIPTION
# What

Replace references to cf-release with cf-deployment, and adjust copy to suit.

It's a minimal change that seems to fit the approach we're using whilst we transition to cf-deployment. We expect the processes to change when / if we make it to cf-deployment. For example, we may use ops files to modify the cf-deployment.yml file in the future, relieving us of the burden of matching component release numbers to releases of cf-deployment.

We want to keep this document up-to-date in case people get confused and start using cf-release again (?)

# How to review

Read the changes. See them in a browser using the instructions in the README.

# Who can't review

@camelpunch nor @LeePorte 