### PR TITLE
[#120268519] Monitoring gorouter latency

### DIFF
--- a/docs/support/responding_to_alerts.md
+++ b/docs/support/responding_to_alerts.md
@@ -270,3 +270,13 @@ The following Trusted Advisor checks cause expected warnings:
 * S3 Bucket Permission's for `gds-paas-*-ci-releases-blobs` are required to be publicly accesible so it is safe to mark these as excluded.
 * ELB Listener Security for `*-ssh-proxy`: This ELB is in TCP mode and so this warning is expected
 * Security Group - Specified Ports Unrestricted for `*-sshproxy`: We intentionally allow port 2222 for `cf ssh` access so it is safe to mark this as excluded.
+
+## Gorouter high latency alerts
+
+If you see an alert for gorouter latency being high;
+
+* Check with the team if we have any known load testing occuring either by the team or by a tenant
+* Visit [kibana](https://logsearch.cloud.service.gov.uk/) and filter by `@source.component: gorouter` then add in `gorouter.host` to the table, this will show you which hosts are being most used currently
+* Contact the team who own the service to see if they are aware of anything happening
+
+As this is the first monitor of this type please investigate the gorouters to discover the issue they are encountering. We have previously seen high resource usage (CPU and Memory) these should be checked in the first case.


### PR DESCRIPTION
## What

This PR adds methods for investigating and dealing with high latency alerts
to the team manual. I expect that this section should be uexpanded upon
after team discussion.

## How to review

Checkout this branch and run `mkdocs serve` then visit http://127.0.0.1:8000/support/responding_to_alerts/ to make sure the content renders properly and makes sense.

## Who can merge?

No @LeePorte