### PR TITLE
[#155463709] Use secrets_ instead of secrets. for cf-secrets.yml

### DIFF
--- a/docs/guides/Restoring_the_CF_databases.md
+++ b/docs/guides/Restoring_the_CF_databases.md
@@ -63,7 +63,7 @@ make tunnel TUNNEL=5432:${db_endpoint}:5432
 ```
 db_password=$(
   concourse/scripts/val_from_yaml.rb \
-  secrets.cf_db_master_password \
+  secrets_cf_db_master_password \
   <(aws s3 cp s3://gds-paas-${DEPLOY_ENV}-state/cf-secrets.yml -) \
 )
 ```


### PR DESCRIPTION
[#155463709 Migrate Spruce `grab` to bosh variables](https://www.pivotaltracker.com/story/show/155463709)

What?
----

In alphagov/paas-cf#1249 we have flatten the variables from
cf-secrets.yml to follow the convention `secrets_<name>`.

We update the manual runbooks to reflect this

How to review?
----------

Code review

Who?
----
Anyone but @keymon