### PR TITLE
[#156302820] gorouter logs are under a single @source.component

### DIFF
--- a/docs/support/finding_activity.md
+++ b/docs/support/finding_activity.md
@@ -87,15 +87,16 @@ There may be times, where we'd need to be troubleshooting or reviewing an API Ac
 
 ## Gorouter
 
-In kibana, filtering the `@source.component` to `gorouter` will show the access logs. Request details are also parsed to allow searches like:
+In kibana, filtering the `@source.component` to `gorouter` will show the access logs, error logs, and route registration events.
+
+You can filter access logs only with:
+
+- `tags:gorouter_access_log`
+
+Request details are also parsed to allow searches like:
 
 - `NOT gorouter.status: 200`
 - `gorouter.method: POST`
-
-You can find additional context searching for:
-
- - `@source.component:gorouter.stdout`: logs written to stdout, including route registration events
- - `@source.component:gorouter.stderr`: logs written to stderr, including application connection errors
 
 ## Router HAProxy
 


### PR DESCRIPTION
## What

In updating to use blackbox in alphagov/paas-cf#1298 we can no longer
identify/tag the separate types of logs from gorouter. Access logs will
continue to be parsed and you can filter them based on their additional
fields, but the other log types will be unparsed and available from the
same `@source.component:gorouter` query.

## How to review

Review with alphagov/paas-cf#1298

## Who can review

Anyone.