### PR TITLE
[#156802717] Link to pass store secret rotation

### DIFF
--- a/docs/team/rotating_credentials.md
+++ b/docs/team/rotating_credentials.md
@@ -1,12 +1,21 @@
+## Third-party services
+
+We store credentials for third-party services in [`pass`](https://www.passwordstore.org/) stores which have some documentation about rotating the secrets held in them:
+
+- https://github.com/alphagov/paas-credentials/blob/master/SECRET_ROTATION.md
+- https://github.com/alphagov/paas-credentials-high/blob/master/SECRET_ROTATION.md
+
+## Platform
+
 From time to time, it might be necessary to rotate our platform credentials. We have created helper tasks in the deployer and bootstrap pipelines, credentials tab, to clean passwords that we know are safe to re-set.
 
-## Rotating passwords
+### Rotating passwords
 
 Rotating passwords consists of two phases. First, you delete credentials using one of the helper tasks. There's one for CF (in the deployer pipeline), one for BOSH and one for Concourse (in the bootstrap pipeline). These tasks exclude passwords that are difficult or not safe to rotate and clean all other passwords. We do also delete generated ssh keys in these tasks.
 
 Second phase consists of running the main pipeline (on deployer for CF, on bootstrap for BOSH and Concourse) to generate new credentials and apply them. Ensure that there is nothing else triggering this 2nd phase run, as that would mean you would be rotating passwords _and_ trying to apply some changes at the same time, which might not work and you could end up with broken deployment. Pipeline run should complete successfully and all tests should pass. There should be no interruptions to deployed apps.
 
-## Rotating certificates
+### Rotating certificates
 
 Rotating the certificates that Cloud Foundry using internally for mutual TLS
 between components is a much longer process. You need to:
@@ -27,7 +36,7 @@ The deployer Concourse has a job for triggering the rotation of AWS keys generat
 
 The job works by removing the resources from the Terraform state file (without touching the keys themselves). This causes new access keys to be generated on the next pipeline run. Unused keys are deleted in a post-deploy job after every pipeline run. This operation is safe to do at any time, so it triggers automatically every 30 days. It is also included as a step in the manual credential rotation job.
 
-## Limited functionality during rotation
+### Limited functionality during rotation
 
 We have lot of functionality that requires credentials outside of the pipeline. These are mainly our scripts that are orchestrated via Makefile. Most of the tasks (like `bosh-cli` or any ssh tasks) will not work during rotation, as they need credentials (concourse password, ssh keys) that have been deleted and are either not available or not applied yet.
 


### PR DESCRIPTION
## What

In addition to the documentation that we have about rotating platform
secrets via the deploy pipelines, because these weren't previously easy
to find or know about.

## How to review

Review alphagov/paas-credentials#115 and alphagov/paas-credentials-high#34 first, then make sure the links work and render correctly.

## Who can review

Anyone.