### PR TITLE
Reposition the Styleguides under the Guides

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -38,15 +38,6 @@ platform. Public-facing documentation can be found at [docs.cloud.service.gov.uk
  - [Spruce (for merging YAML)](guides/spruce/)
  - [upgrading CF, bosh and stemcells](guides/upgrading_CF,_bosh_and_stemcells/)
 
-## Support
-
- - [Finding activity](support/finding_activity/)
- - [Incident process](support/incident_process/)
- - [Responding to alerts](support/responding_to_alerts/)
- - [Responding to security issues](support/responding_to_security_issues/)
- - [Support roles and responsibilities](support/roles_and_responsibilities/)
- - [Support manual](support/support_manual/)
-
 ### Styleguides
 
 This section contains some team-specific styleguides. These should be used in
@@ -56,6 +47,15 @@ addition to the [GDS styleguides]().
 
  - [YAML](styleguides/YAML/)
  - [Concourse pipelines](styleguides/concourse_pipeline/)
+
+## Support
+
+ - [Finding activity](support/finding_activity/)
+ - [Incident process](support/incident_process/)
+ - [Responding to alerts](support/responding_to_alerts/)
+ - [Responding to security issues](support/responding_to_security_issues/)
+ - [Support roles and responsibilities](support/roles_and_responsibilities/)
+ - [Support manual](support/support_manual/)
 
 ## Architecture decision records
 


### PR DESCRIPTION
## What

This fixes a mistake of mine from Firebreak week. See commit message.

## How to review

Code review or preview in a browser (`bundle exec middleman server`).

## Who can review

Not @46bit