### PR TITLE
[#156658598] Allow google to index the site.

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -2,6 +2,8 @@ require 'govuk_tech_docs'
 require 'html-proofer'
 
 activate :directory_indexes
+page '/google*.html', directory_index: false
+
 activate :relative_assets
 set :relative_links, true
 

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -17,6 +17,3 @@ ga_tracking_id:
 # If your ToC is too long, reduce this number and we'll only show higher-level
 # headings.
 max_toc_heading_level: 6
-
-# Prevent robots from indexing (e.g. whilst in development)
-prevent_indexing: true

--- a/source/google52ece46ed12b8c21.html
+++ b/source/google52ece46ed12b8c21.html
@@ -1,0 +1,1 @@
+google-site-verification: google52ece46ed12b8c21.html


### PR DESCRIPTION
## What

We want to use a Google site-scoped search box on this site. For that to work we need Google to index it.

This also adds a google site verification file so that it can be added to the Search Console

## How to review

* Run this locally
* Verify that there is no `<meta name="robots" content="noindex">` tag in the `<head>`
* Verify that `http://localhost:4567/google52ece46ed12b8c21.html` returns the file.

## Who can review

Not me.