### PR TITLE
[#156658598] Update to use a custom domain

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -1,10 +1,10 @@
 # Host to use for canonical URL generation (without trailing slash)
-host: https://alphagov.github.io/paas-team-manual
+host: https://team-manual.cloud.service.gov.uk
 
 # Header-related options
 show_govuk_logo: false
 service_name: PaaS Team Manual
-service_link: https://alphagov.github.io/paas-team-manual
+service_link: https://team-manual.cloud.service.gov.uk
 phase: Internal
 
 # Links to show on right-hand-side of header


### PR DESCRIPTION
## What
Using a [custom domain](https://blog.github.com/2018-05-01-github-pages-custom-domains-https/) avoids issues with some internal links that
linke between sections and therefore have to use an absolute path. When
deployed on the alphagov.github.io domain, Github Pages adds a
paas-team-manual path prefix, which breaks these links. The link checker
doesn't pick these up as broke because the prefix doesn't exist when
building/viewing locally.  Using a custom domain avoids the need for
this prefix.

## How to review

* Build locally ('bundle exec middleman build`)
* Verify that absolute links use the correct hostname

## :rotating_light: Before Merging :rotating_light:

https://github.com/alphagov/paas-aws-account-wide-terraform/pull/124 must be merged and applied, and Github Pages must be configured accordingly before this is merged.

## Who can review

Not me