### PR TITLE
[#156658598] Add a CNAME file to set the Github Pages custom domain

### DIFF
--- a/source/CNAME
+++ b/source/CNAME
@@ -1,0 +1,1 @@
+team-manual.cloud.service.gov.uk


### PR DESCRIPTION
## What

When you configure a Custom Domain in the repo settings, Github actually
adds a commit with a `CNAME` file to the gh-pages branch. Because this
wasn't present in the source, each deploy was removing this file which
removed the custom domain for the site. This isn't mentioned on the main
github docs for custom domains[1], but it is mentioned in the
troubleshooting section[2].

[1]https://help.github.com/articles/adding-or-removing-a-custom-domain-for-your-github-pages-site/
[2]https://help.github.com/articles/troubleshooting-custom-domains/#github-repository-setup-errors

## How to review

* Build the site (`bundle exec rake build`)
* Verify the `CNAME` file is added to the root of the build dir
* Verify it contains the bare hostname only.

## Who can review

Not me.