### PR TITLE
Update govuk_tech_docs gem to fix page titles.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
 # Include the tech docs gem
-gem 'govuk_tech_docs'
+gem 'govuk_tech_docs', '~> 1.2'
 
 gem 'html-proofer'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     autoprefixer-rails (6.7.7.2)
       execjs
-    backports (3.11.1)
+    backports (3.11.3)
+    chronic (0.10.2)
     chunky_png (1.3.10)
     coffee-script (2.4.1)
       coffee-script-source
@@ -31,19 +32,21 @@ GEM
       sass (>= 3.2, < 3.5)
     concurrent-ruby (1.0.5)
     contracts (0.13.0)
-    dotenv (2.2.1)
+    dotenv (2.4.0)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
     ethon (0.11.0)
       ffi (>= 1.3.0)
-    eventmachine (1.2.5)
+    eventmachine (1.2.6)
     execjs (2.7.0)
     fast_blank (1.0.0)
-    fastimage (2.1.1)
+    fastimage (2.1.3)
     ffi (1.9.23)
-    govuk_tech_docs (1.1.0)
+    govuk_tech_docs (1.2.0)
+      activesupport
+      chronic (~> 0.10.2)
       middleman (~> 4.0)
       middleman-autoprefixer (~> 2.7.0)
       middleman-compass (>= 4.0.0)
@@ -142,7 +145,7 @@ GEM
       activesupport (>= 3.1)
     parallel (1.12.1)
     public_suffix (3.0.2)
-    rack (2.0.4)
+    rack (2.0.5)
     rack-livereload (0.3.17)
       rack
     rake (12.3.1)
@@ -172,7 +175,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  govuk_tech_docs
+  govuk_tech_docs (~> 1.2)
   html-proofer
   middleman-gh-pages
   mini_racer (~> 0.1.15)


### PR DESCRIPTION
## What

These were defaulting to "GOV.UK Documentation" on all pages. With the
update to the gem, they now pick up the service name specified in
config/tech-docs.yml.

## How to review

* Run locally (`bundle exec middleman serve`)
* Verify the page `<title>`s are now saying "PaaS Team Manual"
* Verify it still looks ok.

## Who can review

Not me.