### PR TITLE
Add warning around rotating CA certs.

### DIFF
--- a/source/team/rotating_credentials.html.md.erb
+++ b/source/team/rotating_credentials.html.md.erb
@@ -19,7 +19,16 @@ Second phase consists of running the main pipeline (on deployer for CF, on boots
 
 ### Rotating certificates
 
-Rotating the certificates that Cloud Foundry using internally for mutual TLS
+Rotating the internal certificates has 2 phases similar to rotating passwords. First we delete the existing certs, and then we run a deploy to generate and use new certificates.
+
+1. Run `rotate-cf-certs-leafs` to delete existing non-CA certs
+1. Run `create-cloudfoundry` to generate new certs and deploy them
+
+#### Rotating CA certificates
+
+**Important:** Rotating CA certs is known to cause downtime. See [the story to fix it](https://www.pivotaltracker.com/story/show/157032509) for details.
+
+Rotating the CA certificates that Cloud Foundry is using internally for mutual TLS
 between components is a much longer process. You need to:
 
 1. Run `rotate-cf-certs-cas` to copy existing CAs into `_old` suffixes


### PR DESCRIPTION
## What

It's currently not safe to rotate CA certs - it causes downtime.

## How to review

Read, check it makes sense.

## Who can review

Not me.
