### PR TITLE
[#156946241] Update status page early before we know whether a reported issue is a incident

### DIFF
--- a/source/support/incident_process.html.md.erb
+++ b/source/support/incident_process.html.md.erb
@@ -33,11 +33,11 @@ Ensure that we schedule the post mortem and publish our incident report Draft th
 
 <a id="if-youre-incident-comms"></a>
 
-1. Let the PaaS team know about the incident on #the-government-paas Slack channel
-2. Tell internal stakeholders: send a summary of the incident as soon as possible to the [GaaP incidents email list](mailto:gaap-incidents@digital.cabinet-office.gov.uk) (this tells the GaaP team and a few others - internal to GDS - including IA team members).
-3. Tell tenants: log in to our [Statuspage account](https://www.statuspage.io/). This is where you will send the incident alert email from, using the [saved templates](https://manage.statuspage.io/pages/h4wt7brwsqr0).
-5. Update tenants hourly using the templates saved in our statuspage account.
-6. Ensure that all decisions/comms are entered into the timeline section of the incident report.
+1. Let the PaaS team know about the incident on #paas Slack channel
+2. Notify the tenants about the investigation by creating a new incident in [Statuspage](/team/statuspage/) using the template "Possible issue being investigated".
+3. Tell internal stakeholders: send a summary of the incident as soon as possible to the [GaaP incidents email list](mailto:gaap-incidents@digital.cabinet-office.gov.uk) (this tells the GaaP team and a few others - internal to GDS - including IA team members).
+4. Update tenants hourly using the [saved templates](https://manage.statuspage.io/pages/h4wt7brwsqr0) in our Statuspage account.
+5. Ensure that all decisions/comms are entered into the timeline section of the incident report.
 
 [PaaS Emergency contacts and escalations document](https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/1_6zxOjvwY-zrf1D8eDNT9AeRhlcPAocBhC8dmHfRw0Y/edit?usp=sharing) *(restricted access)* provides useful contact information for senior GaaP management escalations for out of hours support.
 
@@ -93,4 +93,3 @@ The person contacted above will decide if they need to alert a member of the GDS
 
 The contact details for the above people, as well as useful contacts, can be found in
 [PaaS Emergency contacts and escalations (restricted access)](https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/1_6zxOjvwY-zrf1D8eDNT9AeRhlcPAocBhC8dmHfRw0Y/edit?usp=sharing)
-

--- a/source/support/roles_and_responsibilities.html.md.erb
+++ b/source/support/roles_and_responsibilities.html.md.erb
@@ -7,7 +7,7 @@ The support rota is on [Pagerduty](https://gds-paas.pagerduty.com/schedules).
 
 For in-hours support, one person from the team will be the Support Lead on a weekly basis. For out of hours support, to begin with, we will have one person from the team on call as Support lead, again on a weekly basis. We will also have a second person on call for Escalations.
 
-If you are on in-hours support, add your shift onto the #the-government-paas slack channel description so your colleagues find it easier to see who is on support. If you need to swap shifts, ask your colleagues if they can swap or cover, update Pagerduty [using an override](https://support.pagerduty.com/hc/en-us/articles/202830170-Creating-and-Deleting-Overrides).
+If you are on in-hours support, add your shift onto the #paas slack channel description so your colleagues find it easier to see who is on support. If you need to swap shifts, ask your colleagues if they can swap or cover, update Pagerduty [using an override](https://support.pagerduty.com/hc/en-us/articles/202830170-Creating-and-Deleting-Overrides).
 
 ## Expectations
 The broad response times and action that our users expect from us are documented in the [PaaS Support Overview (Gdoc)](https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/1FLiKPmM61ikO1MJNo96YpxGaYPUMb8CdAcWPnzBBa0U/edit?usp=sharing), and [Product pages](https://www.cloud.service.gov.uk/support.html). Please read it so you know what they expect. These expectations are different for in-hours and out of hours support.


### PR DESCRIPTION
## What

Update status page early before we know whether a reported issue is a incident.

The related templated was already created in Statuspage.

## How to review

Read it and middleman it.

## Who can review it

Not me or a middleman.