### PR TITLE
Replace names of Product Managers with role

### DIFF
--- a/source/team/notifying_tenants.html.md.erb
+++ b/source/team/notifying_tenants.html.md.erb
@@ -18,11 +18,11 @@ Follow the guidance in [this section](/support/incident_process/#if-youre-incide
 
 Write a draft email and share it [here.](https://drive.google.com/drive/folders/0Bw4pWpR0IbJfWGFEMVBBZlFsSDQ)
 
-Get Tom or Jess to proof-read and add any 'product-y' elements - we want to make sure our notifications are consistent and meet the GDS style guidelines. If the email is time-sensitive and Tom/Jess are not around, get another member of the team to proof-read the email before it's sent.
+Get a Product Manager to proof-read and add any 'product-y' elements - we want to make sure our notifications are consistent and meet the GDS style guidelines. If the email is time-sensitive and there are no Product Managers around, get another member of the team to proof-read the email before it's sent.
 
 ### Announcing new features
 
-These announcements are our chance to showcase how we're developing GOV.UK PaaS and will be written and sent by the product managers. Tom/Jess may ask the team member who worked on the story to provide some technical details that can be inclued in the email.
+These announcements are our chance to showcase how we're developing GOV.UK PaaS and will be written and sent by the product managers. Product Managers may ask the team member who worked on the story to provide some technical details that can be inclued in the email.
 
 
 ## Sending notification emails to tenants


### PR DESCRIPTION
## What

Tom no longer works on the team. Refer to the people by their roles, so
that we don't need to update this for subsequent team changes.

## Why

Check the rationale and content.

## How to review

Anyone.