### PR TITLE
[#154917736] Add notes about Cloud Foundry internal certificates to Responding to alerts

### DIFF
--- a/source/support/responding_to_alerts.html.md.erb
+++ b/source/support/responding_to_alerts.html.md.erb
@@ -186,6 +186,14 @@ fundimental connectivity issue to the reported endpoint.
 The `cf logs` output of the paas-metrics app may contain additional
 information. This is deployed to the 'monitoring' space of the 'admin' org.
 
+## Cloud Foundry internal certificates
+
+We generate several certificates for Cloud Foundry which need to be rotated regularly (most of them have a 1 year expiry).
+
+We have a [Concourse job](https://deployer.cloud.service.gov.uk/teams/main/pipelines/create-cloudfoundry/jobs/check-certificates/builds/latest) which checks if we have certificates expiring in less than 30 days.
+
+If we need to rotate any of the certificates please follow the intructions [here](/team/rotating_credentials/#rotating-certificates).
+
 ## Logsearch/ELK queue threshold limits
 
 We use [Logsearch (ELK


### PR DESCRIPTION
## What

We have a Datadog monitor which will alert if any of the internal Cloud Foundry certificates will expire soon. We want to link to this section so the person on support will understand what the alert means.

## How to review

Code review, middleman.

## Who can review it

Not me.