### PR TITLE
[#157032509] Remove warning about rotating CA certs.

### DIFF
--- a/source/team/rotating_credentials.html.md.erb
+++ b/source/team/rotating_credentials.html.md.erb
@@ -26,8 +26,6 @@ Rotating the internal certificates has 2 phases similar to rotating passwords. F
 
 #### Rotating CA certificates
 
-**Important:** Rotating CA certs is known to cause downtime. See [the story to fix it](https://www.pivotaltracker.com/story/show/157032509) for details.
-
 Rotating the CA certificates that Cloud Foundry is using internally for mutual TLS
 between components is a much longer process. You need to:
 


### PR DESCRIPTION
## What

Now that the referenced story has been played, this warning no longer
applies.

## How to review

Verify it makes sense to remove this

## Who can review

Not me.