### PR TITLE
Commands to get ext IPs and RDS DBs for pentest

### DIFF
--- a/source/guides/Tenant_Application_Penetration_Testing.html.md.erb
+++ b/source/guides/Tenant_Application_Penetration_Testing.html.md.erb
@@ -64,3 +64,20 @@ The `cdn-route` service uses a CloudFront distribution. You can discover these d
 aws cloudfront list-distributions \
 | jq '.DistributionList.Items[] | select(.Comment == "cdn route service") | .Id' --raw-output
 ```
+
+## Find external IPs (NAT)
+
+```
+aws ec2 describe-nat-gateways | jq -r '.NatGateways[].NatGatewayAddresses[].PublicIp
+```
+
+## Find RDS instances from a given org
+
+Assuming you are logged in the production CF and `AWS_DEFAULT_REGION` set to the right region
+
+```
+ORG=tenant-org
+cf curl /v2/organizations/$(cf org --guid $ORG)/services \
+| jq -r '.resources[].entity | select(.description | contains("RDS")) | "arn:aws:rds:${AWS_DEFAULT_REGION}:$(aws sts get-caller-identity --output text  --query Account):db:rdsbroker-\(.unique_id)"'
+
+```


### PR DESCRIPTION
When requesting pen-tests approvals to AWS we also shall send
the external IPs of our cluster (NAT instances, I guess) and the
RDS instances affected.

We assume that only the RDS instances for the given tenant org
will be affected.