### PR TITLE
Configure CircleCI to ignore gh-pages branch.

### DIFF
--- a/source/.circleci/config.yml
+++ b/source/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: 2
+jobs:
+  build:
+    branches:
+      ignore:
+        - gh-pages
+    docker:
+      - image: alpine
+    steps:
+      - run: echo "no-op"


### PR DESCRIPTION
## What

This adds a dummy CircleCI config file to the source directory so that
it gets included in the gh-pages branch. This will prevent CircleCI from
running a v1.0 build on the gh-pages branch, and erroring because it
can't detect any tests.

How to review
-------------

It's not really possible to fully test this without merging to master (as that's where the `gh-pages` branch is built from). I tested as follows:

* I ran a `bundle exec rake build` to confirm that the circle config from the source directory gets included in the build.
* I created a test branch with this config to verify that the build gets skipped (see the `alext_test` build here: https://circleci.com/gh/alphagov/paas-team-manual)

Who can review
--------------

Not me.