### PR TITLE
Update sprockets to 3.7.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
     rouge (2.2.1)
     sass (3.4.25)
     servolux (0.13.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     temple (0.8.0)
@@ -183,4 +183,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
## What

Earlier versions have an information leak CVE[1]. We're inlikely to be
vulnerable as this is only used to generate a static site, but it makes
sense to upgrade anyway to avoid notifications from Github etc.

[1]https://groups.google.com/forum/#!topic/ruby-security-ann/2S9Pwz2i16k

How to review
-------------

* Verify the site still builds and looks ok.

Who can review
--------------

Not me.