### PR TITLE
Update AWS access instructions to use assume-role

### DIFF
--- a/source/team/managing_aws_access.html.md
+++ b/source/team/managing_aws_access.html.md
@@ -4,55 +4,19 @@ Each AWS account has [root account](http://docs.aws.amazon.com/general/latest/gr
 
 Instead we access AWS resources using [IAM](http://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html).
 
-## IAM Roles
+## IAM Roles for VMs
 
 We use [IAM roles](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) via [intance profiles](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) on our EC2 instances to delegate particular restricted permissions to processes running on those instances.
 
-## IAM Groups
+## IAM Roles for Humans
 
-We use [IAM groups](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_groups.html) to specify permissions for categories of user.
+We use separate IAM roles for users on our team to use via AWS' assume-role
+feature. See the [RE manual](https://reliability-engineering.cloudapps.digital/iaas.html#access-aws-accounts)
+for details on how to do this.  The available role ARNs that you'll need for
+this are documented [in paas-aws-account-wide-terrafom here](https://github.com/alphagov/paas-aws-account-wide-terraform/blob/master/doc/assume_role_arns.md)
 
-For example, contractors and civil servants are different groups.
+## Role configuration
 
-## IAM Users
-
-We create an [IAM user](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_users.html) for each team member, in each of our AWS accounts.
-
-Each user has separate [access keys](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) which need to be present in the environment for the AWS commandline tools to work.
-
-We have turned on [MFA](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa.html) for all team members.
-
-# Temporary Credentials
-
-We use [STS](http://docs.aws.amazon.com/STS/latest/APIReference/API_GetSessionToken.html) to provide [temporary credentials](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html) for command line access to AWS.
-
-The long-lived access keys cannot be associated with MFA.
-
-Since we require MFA to perform most AWS operations, we must use STS tokens generated using MFA instead.
-
-We have a script [`create_sts_token.sh` in paas-cf](https://github.com/alphagov/paas-cf/blob/master/scripts/create_sts_token.sh) which manages token creation and storage for you.
-
-Because you will have a user for each AWS account, but only one terminal session, it is up to you to integrate the generated keys into your session.
-
-For example, you might add a function`:
-```
-export PAAS_CF_DIR="path/to/paas-cf"
-
-sts() {
-  "${PAAS_CF_DIR}/scripts/create_sts_token.sh" && source "${HOME}/.aws_sts_tokens/${AWS_ACCOUNT}.sh"
-}
-```
-
-along with an alias per account:
-```
-alias aws_staging='
-export AWS_DEFAULT_REGION=eu-west-1
-export DEPLOY_ENV="staging"
-export AWS_ACCOUNT="staging"
-export AWS_ACCESS_KEY_ID=$(pass aws/staging/id)
-export AWS_SECRET_ACCESS_KEY=$(pass aws/staging/secret)
-sts
-'
-```
-
-This approach would require you to store your long-lived credentials in a personal `pass` store. You may prefer an alternative approach, but this should give you an idea of what to do.
+We manage all these IAM roles, and the corresponding policies using Terraform.
+The config is in the [account-wide-terraform](https://github.com/alphagov/paas-aws-account-wide-terraform)
+repo. This includes defining who is allowed to assume the above roles.


### PR DESCRIPTION
## What

We now have the necessary config in place to support using assume-role
from the central gds-users account instead of needing individual users
in each account. This updates our docs to reflect this, and to link out
to the RE manual for how to set this up.

How to review
-------------

Review along with https://github.com/alphagov/paas-aws-account-wide-terraform/pull/139.

Check the new content makes sense and contains enough detail.

Who can review
--------------

Not me
