### PR TITLE
[#SUPPORT] Fix dead link to VPC Peering docs

### DIFF
--- a/source/architecture_decision_records/ADR019-accessing-user-provided-services.html.md
+++ b/source/architecture_decision_records/ADR019-accessing-user-provided-services.html.md
@@ -85,4 +85,4 @@ We will offer VPC peering to tenants in specific cases where it is appropriate.
 Where we don't presently offer a specific backing-service, tenants have an
 option to provision their own service and access it without having to expose it
 to the Internet. The process for doing this is documented
-[here](https://github.com/alphagov/paas-cf/blob/master/doc/vpc_peering.md).
+[here](/guides/vpc_peering/).


### PR DESCRIPTION
What
----

We moved the documentation into the team manual because nobody could
find it. For some reason when I searched the team manual the only link I
found was this one, which was dead.

Let's point it at the right place :)

How to review
-------------

* :eyes: :computer:

Who can review
--------------

Not @richardTowers