### PR TITLE
Upgrade rack to 2.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,7 @@ GEM
       activesupport (>= 3.1)
     parallel (1.12.1)
     public_suffix (3.0.2)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-livereload (0.3.17)
       rack
     rake (12.3.1)


### PR DESCRIPTION
## What

To fix CVE-2018-16470 [1]. This isn't a significant thing for us as
this is a static site generator, so rack isn't running in production,
but it's worth updating to avoid the noise etc.

[1]https://groups.google.com/forum/#!msg/rubyonrails-security/U_x-YkfuVTg/xhvYAmp6AAAJ

How to review
-------------

Code review should be enough

Who can review
--------------

Not me.