### PR TITLE
[#162612712] Update Datadog to Prometheus

### DIFF
--- a/source/guides/upgrading_CF,_bosh_and_stemcells.html.md
+++ b/source/guides/upgrading_CF,_bosh_and_stemcells.html.md
@@ -61,7 +61,7 @@ being excluded at the time of writing.
 
 You should test the upgrade changeset:
 
-* From a fully deployed master with Datadog enabled and `SLIM_DEV_DEPLOYMENT=false` set, which is equivalent to the change that will happen in
+* From a fully deployed master with `SLIM_DEV_DEPLOYMENT=false` set, which is equivalent to the change that will happen
   in production.
 * Deploying a fresh CF, which is something we frequently do in our
   development environments after the autodelete-cloudfoundry pipeline
@@ -81,10 +81,6 @@ Buildpack upgrades are typically done as a separate story. You should upgrade th
 Send an email to users following [the upgrade template](/team/notifying_tenants/#cf-upgrade).
 
 ## Problems encountered previously
-
-### Datadog
-
-Our dev environments typically don't have Datadog enabled, so changes relating to our Datadog monitors tend to get missed. Real examples include: process checks failing because the search string used to check them is no longer valid; and manifest updates being missed because the manifest stubs for Datadog tend to be in a different location in the repository, as they are shared across all deployed jobs. The recommendation is to have Datadog enabled while working on an upgrade story and check for triggered monitors.
 
 ### DNS name resolution.
 We encountered a wide variety of acceptance and smoke test failures which were intermittent. This was due to DNS health check failures. Consul uses these health checks to validate the consistency of the DNS records it serves, and will expire DNS records where the health check has failed.

--- a/source/incident_management/incident_process.html.md
+++ b/source/incident_management/incident_process.html.md
@@ -119,7 +119,3 @@ Aiven monitors its services 24 hours a day 365 days a year, and provides free em
 - rapidly address any issues in system operations requiring manual intervention
 
 Responses are provided on a best-effort basis during the same or next business day. Email [support@aiven.io](mailto:support@aiven.io) for all support requests.
-
-### DataDog
-
-We do not currently have dedicated support for datadog. You can use live chat to contact DataDog between 15:00 and 00:00 UTC, or email their Support Team at support@datadoghq.com. Refer to https://www.datadoghq.com/support/ for more information.

--- a/source/incident_management/responding_to_alerts.html.md
+++ b/source/incident_management/responding_to_alerts.html.md
@@ -4,7 +4,7 @@ Tips for responding to alerts when you are on support.
 
 ## Failed logins
 
-In case of security incident, for example when alerted of a brute-force attack by datadog monitors,
+In case of security incident, for example when alerted of a brute-force attack by Prometheus monitors,
 it may help to look at UAA logs.
 
 The access logs is on the UAA VMs in `/var/vcap/sys/log/uaa/localhost_access.log`.
@@ -37,8 +37,7 @@ dependencies are working. If any are not working then the healthcheck
 endpoint returns a 500 response code and response body containing the
 errors.
 
-The version of the DataDog agent that we currently use doesn't report the
-response body, which can make it hard to determine the actual problem. To
+Prometheus doesn't report the response body, which can make it hard to determine the actual problem. To
 get this information you will need to SSH to any Cloud Foundry VM and query
 the endpoint yourself:
 
@@ -57,9 +56,7 @@ cloudfoundry error: Could not get api /v2/info: EOF
 
 ## RDS Failures
 
-On rare occasion, we may get an RDS Failure event coming through to our Datadog
-via the RDS Integration. Unfortunately, many types of `failure` event are not
-resolvable without getting in touch with AWS. In some circumstances you may be
+Unfortunately, many types of `failure` event are not resolvable without getting in touch with AWS. In some circumstances you may be
 able to restore an instance using [our point-in-time-restore
 instructions](/guides/Restoring_the_CF_databases/).
 

--- a/source/support/responding_to_security_issues.html.md
+++ b/source/support/responding_to_security_issues.html.md
@@ -9,7 +9,7 @@ If a breach is suspected to have occurred, [alert Information Assurance (IA) imm
 
 ## How we learn of issues
 
-* Automated datadog CVE notifications from the [CloudFoundry security RSS feed](https://www.cloudfoundry.org/category/security/). This is implemented with [IFTTT](https://ifttt.com) - credentials are in `paas-pass`
+* Automated CVE notifications from the [CloudFoundry security RSS feed](https://www.cloudfoundry.org/category/security/). This is implemented with [IFTTT](https://ifttt.com) - credentials are in `paas-pass`
 * Notifications from [cf-dev](https://lists.cloudfoundry.org/archives/list/cf-dev@lists.cloudfoundry.org/)
 * Notifications in slack from a team member, the #security channel, or others
 

--- a/source/support/support_manual.html.md
+++ b/source/support/support_manual.html.md
@@ -87,5 +87,6 @@ This is now in its [own section](/incident_management/incident_process/).
 * [Prod pipeline](https://deployer.cloud.service.gov.uk)
 * [Prod logs](https://logsearch.cloud.service.gov.uk)
 * [All pipelines dashboard](https://dsingleton.github.io/frame-splits/index.html?title=&layout=3row&url%5B%5D=https%3A%2F%2Fdeployer.london.staging.cloudpipeline.digital%2Fteams%2Fmain%2Fpipelines%2Fcreate-cloudfoundry&url%5B%5D=https%3A%2F%2Fdeployer.cloud.service.gov.uk%2Fteams%2Fmain%2Fpipelines%2Fcreate-cloudfoundry&url%5B%5D=https%3A%2F%2Fdeployer.london.cloud.service.gov.uk%2Fteams%2Fmain%2Fpipelines%2Fcreate-cloudfoundry)
-* [Monitor summary](https://app.datadoghq.com/screen/222842/user-impact-for-our-monitor-do-not-edit)
+* [Monitor summary - Ireland](https://grafana.cloud.service.gov.uk/d/paas-user-impact/user-impact-prod?refresh=5s&orgId=1)
+* [Monitor Summary - London](https://grafana.london.cloud.service.gov.uk/d/paas-user-impact/user-impact-prod-lon?refresh=5s&orgId=1)
 * Fourth wall (PR dashboard): `https://alphagov.github.io/fourth-wall/?token=${GITHUB_API_TOKEN}&team=alphagov/team-government-paas-readonly` (insert github readonly account token)

--- a/source/team/dashboard_mac_mini.html.md
+++ b/source/team/dashboard_mac_mini.html.md
@@ -1,26 +1,20 @@
-# Dashboard Mac Mini
+# Dashboard Mac Mini & Chromebox
 
-There are two Mac Minis attached to big screens in our team area. They can show the
+There are two Mac Minis and a Chromebox attached to big screens in our team area. They can show the
 following:
 
 * Outstanding pull requests
 * Concourse pipelines
 * Pingdom public status page
-* Overview of Datadog triggered monitors
+* Overview of Prometheus triggered monitors
 
 Some combination of the above might be shown according to the whims of the team.
 If we want to display multiple different views on a single screen, we use
 [frame-splits](https://github.com/dsingleton/frame-splits).
 
-If you need access, you can walk up and use the mouse and keyboard, or connect via the OSX Screen Sharing app.
+If you need access, you can walk up and use the mouse and keyboard.
 
-The credentials for this are in the `paas-pass` password store.
-
-To connect to the first machine, you need to be on the `CDN02_test` wifi network.
-This network is not configured by default on newly provisioned laptops, so talk to someone else on the team if you need the wifi password.
-The second machine is on `Bardeen`.
-You can find the machines in the Network section of an OSX Finder window, but only if you are on the right network.
-If you open a machine, the finder should show you a `Share screen` button.
+The credentials for these machines and for the chromebox are in the `paas-pass` password store.
 
 ## Outstanding pull requests
 
@@ -59,8 +53,8 @@ You can use the [Pingdom public status page](http://stats.pingdom.com/ejtodj13fq
 
 We use the [Super Auto Refresh](https://chrome.google.com/webstore/detail/super-auto-refresh/kkhjakkgopekjlempoplnjclgedabddk?hl=en) Chrome extension to refresh the page.
 
-## Datadog Triggered Monitors
+## Prometheus Triggered Monitors
 
-We have created a [dashboard in Datadog, called 'User Impact'](https://app.datadoghq.com/screen/222842/user-impact-for-our-monitor-do-not-edit), which displays a count of monitors by trigger status (healthy, warning, critical, or unknown).
+We have created a [dashboard in Grafana, called 'User Impact - prod'](https://grafana.cloud.service.gov.uk/d/paas-user-impact/user-impact-prod?refresh=5s&orgId=1) and [dashboard in Grafana, called 'User Impact - prod-lon'](https://grafana.london.cloud.service.gov.uk/d/paas-user-impact/user-impact-prod-lon?refresh=5s&orgId=1), which displays a count of monitors by trigger status (healthy, warning, critical, or unknown) for each production environment.
 
-The credentials for the Datadog user are in the `paas-pass` password store.
+The credentials for the Grafana mon users can be found by running `make <env> showenv` from paas-cf.

--- a/source/team/pagerduty.html.md
+++ b/source/team/pagerduty.html.md
@@ -37,7 +37,7 @@ The team email notification is added at the end as well to cover any potential g
 
 ## Services
 
-We integrate with Pingdom and Datadog. For each integration we create one *in hours* service that uses the in hours only escalation policy, and one *24x7* service that uses the 24x7 escalation policy.
+We integrate with Pingdom and Prometheus. For each integration we create one *in hours* service that uses the in hours only escalation policy, and one *24x7* service that uses the 24x7 escalation policy.
 
 A special service called *Emergency email* is dedicated to urgent platform issues impacting tenants. Sending an email to it triggers a ZenDesk ticket to be created and an incident in PagerDuty. The incident is attached to the *24x7* escalation policy.
 

--- a/source/team/platform_alerting.html.md
+++ b/source/team/platform_alerting.html.md
@@ -1,6 +1,6 @@
 # Responding to Platform Alerting
 
-Datadog is now being configured to send alerts to teams mailing lists.
+Prometheus is configured to send alerts to teams mailing lists.
 
 You can check and subscribe to these alerts in each corresponding mailing list page (Google Groups):
 

--- a/source/team/statuspage.html.md
+++ b/source/team/statuspage.html.md
@@ -62,7 +62,7 @@ Documentation is available at http://help.statuspage.io/knowledge_base/topics/ov
 
 ## How it was setup
 
-It was set up manually as we didn't have an API endpoint to hit until it had been created. This was a process of signing up using the details in the credentials repo. And then linking both Pingdom and DataDog to Statuspage.io using API keys from each service.
+It was set up manually as we didn't have an API endpoint to hit until it had been created. This was a process of signing up using the details in the credentials repo.
 
 Terraform manages the CNAME in Route53 in order for us to use a custom domain to host the page on.
 


### PR DESCRIPTION
What
----

We are migrating away from Datadog to use Prometheus. This PR
updates the references and information that we have within the team
manual.

This needs to be done to ensure that the person on support has the right
information to hand in order to resolve issues in a timely manner.

How to review
-------------

Code review and run locally

Who can review
--------------

Anyone
