### PR TITLE
[#162612712] Remove Datadog references from ADRs

### DIFF
--- a/source/architecture_decision_records/ADR021-cell-capacity-assignment-2.html.md
+++ b/source/architecture_decision_records/ADR021-cell-capacity-assignment-2.html.md
@@ -94,7 +94,7 @@ Proposed
 We will alert on the following metrics:
 
 - exponentially weighted moving average of used memory (not including cache) averaged over cells > 50%
-- smoothed idle CPU averaged across cells < 50%
+- smoothed idle CPU averaged across cells < 50% (Note: This metric superceeded by [ADR23](/architecture_decision_records/ADR023-idle-cpu-alerting-change/))
 - smoothed container count (as reported by rep) of > 80% of capacity
 - smoothed available memory capacity (as reported by rep) of < 33%
 

--- a/source/architecture_decision_records/ADR021-cell-capacity-assignment-2.html.md
+++ b/source/architecture_decision_records/ADR021-cell-capacity-assignment-2.html.md
@@ -91,12 +91,12 @@ Proposed
 
 ## Consequences
 
-We will alert on the following datadog metrics:
+We will alert on the following metrics:
 
-- exponentially weighted moving average of `system.mem.pct_usable` averaged over cells < 50%
-- smoothed `system.cpu.idle` averaged across cells < 50%
-- smoothed `cf.rep.ContainerCount / cf.rep.CapacityTotalContainers` cells of > 80%
-- smoothed `cf.rep.CapacityRemainingMemory / cf.rep.CapacityTotalMemory` of < 33%
+- exponentially weighted moving average of used memory (not including cache) averaged over cells > 50%
+- smoothed idle CPU averaged across cells < 50%
+- smoothed container count (as reported by rep) of > 80% of capacity
+- smoothed available memory capacity (as reported by rep) of < 33%
 
 We will remove half the cells, but not all in one go. We should start by removing 1/4 of cells.
 

--- a/source/architecture_decision_records/ADR023-idle-cpu-alerting-change.html.md
+++ b/source/architecture_decision_records/ADR023-idle-cpu-alerting-change.html.md
@@ -22,12 +22,12 @@ Accepted
 
 ## Consequences
 
-We will alert on the following datadog metrics:
+We will alert on the following metrics:
 
-- averaged across 1 day `system.cpu.idle` of cells < 33%
+- idle CPU averaged across 1 day of cells < 33%
 
 We will warn on the following datadog metrics:
 
-- averaged across 1 day `system.cpu.idle` of cells < 37%
+- idle CPU averaged across 1 day of cells < 37%
 
 We will not be annoyed by false positive alerts.


### PR DESCRIPTION
What
----

We're removing Datadog, so these no longer apply. Instead of updating
them to refer to the equivalent metrics in the new system, I've reworded
them to generally describe the thing being measured so that they're
agnostic of the metrics system being used, and therefore shouldn't need
updating again if this changes.

I've also added a link to ADR032 from ADR021 as it supersedes one detail of it.

How to review
-------------

Check the new wording makes sense.

Who can review
--------------

Not me.