### PR TITLE
[#163860737] Add new route owner finding guide

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -13,6 +13,7 @@
 
  - [User management](support/CF_UAA_user_management/)
  - [Finding activity](support/finding_activity/)
+ - [Finding route owners](support/finding_route_owners)
  - [Restoring Elasticsearch Backups](support/restoring_elasticsearch_backups/)
  - [Responding to security issues](support/responding_to_security_issues/)
  - [Support roles and responsibilities](support/roles_and_responsibilities/)

--- a/source/support/finding_route_owners.html.md
+++ b/source/support/finding_route_owners.html.md
@@ -1,0 +1,9 @@
+# Finding the owner of a route in cf
+
+1. Install cf lookup-route plugin  with `cf install-plugin -r CF-Community "route-lookup"`
+1. Log into the cf instance where you suspect the route is
+1. Run `cf lookup-route DOMAINNAME` where DOMAINNAME is the one you are looking for
+1. The output will tell you which org/space/app it it bound to
+1. Run `cf org-users ORG-NAME` ORG-NAME is the first bit of the output from cf lookup-route
+1. You now have a list of all the org managers
+


### PR DESCRIPTION
What
----

During a previous incident it wasn't clear how to quickly find the org managers responsible for a particular route. This PR adds a guide into the support section on how to achieve this.

How to review
-------------

Run the branch locally and make sure the new content makes sense

Who can review
--------------

anyone