### PR TITLE
Update incident process to restore original meaning

### DIFF
--- a/source/incident_management/incident_process.html.md
+++ b/source/incident_management/incident_process.html.md
@@ -11,7 +11,7 @@ This section summarises :
 
 When an incident happens, the person on support must:
 
-- nominate an incident lead; this person must have production access, and be the person on support
+- nominate an incident lead; this person must have production access, and may be the person on support
 - nominate an incident comms person; during out-of-hours this can be the person on the PaaS escalation rota
 - join #paas-incident on Slack if required
 


### PR DESCRIPTION
What
----

The Tech writer review appears to have changed the meaning of this line - from "this may be the person on support, it now reads as "this must be the person on support"

I have restored the original meaning of the line

How to review
-------------

Read the new wording, and confirm it is equivalent to the original intention of the line.

Who can review
--------------

Not @tnwhitwell. May require tech writer 2i (@jonathanglassman)
