### PR TITLE
Use the support email address for notifying tenants

### DIFF
--- a/source/team/notifying_tenants.html.md
+++ b/source/team/notifying_tenants.html.md
@@ -63,7 +63,7 @@ Essential information and actions tenants need to carry out in order to ensure t
     make your user account function correctly
     manage your user account
     send you updates and notices
-    If you have any questions, please contact [...@digital.cabinet-office.gov.uk]
+    If you have any questions, please contact gov-uk-paas-support@digital.cabinet-office.gov.uk
 	  
     Kind regards,
     The GOV.UK PaaS Team


### PR DESCRIPTION
What
----

https://github.com/alphagov/paas-team-manual/pull/291 didn't specify which email address tenants should contact. Presumably it was intended to be filled in when sending the email. But in the vast majority of cases we'll want them to contact our support email address, and using that prevents forgetting to put a valid email address.

Who can review
--------------

Not @46bit