### PR TITLE
Clarify how to rotate Certificate Authorities

### DIFF
--- a/source/team/rotating_credentials.html.md
+++ b/source/team/rotating_credentials.html.md
@@ -42,6 +42,8 @@ Rotating the internal certificates has 2 phases similar to rotating passwords. F
 Rotating the CA certificates that Cloud Foundry is using internally for mutual TLS
 between components is a much longer process. You need to:
 
+1. Run `rotate-cf-certs-leafs` to delete existing non-CA certs
+1. Run `create-cloudfoundry` to generate new certs and deploy them
 1. Run `rotate-cf-certs-cas` to copy existing CAs into `_old` suffixes
 1. Run `create-cloudfoundry` to generate new CAs and deploy them alongside the old CAs
 1. Run `rotate-cf-certs-leafs` to delete existing non-CA certs


### PR DESCRIPTION
What
----

The previous Certificate Authorities rotation instructions did not make completely clear that `rotate-cf-certs-leafs` had to be run first of all. This commit updates the instructions to ensure that people do run that in future.

These instructions need a bigger refactor. But with this update they do work.

How to review
-------------

Code review.

Who can review
--------------

Not @46bit 