### PR TITLE
Update mini_racer to 0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,4 @@ gem 'html-proofer'
 
 gem 'middleman-gh-pages'
 
-# Added at 2018-04-27 17:48:28 +0100 by keymon:
-gem "mini_racer", "~> 0.1.15"
+gem "mini_racer", "~> 0.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     kramdown (1.17.0)
-    libv8 (6.7.288.46.1)
+    libv8 (7.3.492.27.1)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -141,8 +141,8 @@ GEM
       middleman-core (>= 3.2)
       rouge (~> 2.0)
     mini_portile2 (2.4.0)
-    mini_racer (0.1.15)
-      libv8 (~> 6.3)
+    mini_racer (0.2.6)
+      libv8 (>= 6.9.411)
     minitest (5.11.3)
     multi_json (1.13.1)
     nokogiri (1.10.3)
@@ -198,7 +198,7 @@ DEPENDENCIES
   govuk_tech_docs (~> 1.8.2)
   html-proofer
   middleman-gh-pages
-  mini_racer (~> 0.1.15)
+  mini_racer (~> 0.2)
   tzinfo-data
   wdm (~> 0.1.0)
 


### PR DESCRIPTION
What
----
The container being used to build and deploy the team manual was unable to
compile the native extension when installing mini_race 0.1.15. Version 0.2
works for us, is newer, and compiles in the container.


How to review
-------------
Check it compiles on Concourse

Who can review
--------------
Anyone
