### PR TITLE
Update docs for cloud services and SSO

### DIFF
--- a/source/incident_management/responding_to_alerts.html.md
+++ b/source/incident_management/responding_to_alerts.html.md
@@ -18,8 +18,8 @@ You must [Log into logit via Google](https://reliability-engineering.cloudapps.d
 * `principal=XXX` will give you the username
 * `origin=[1.2.3.4]` will give you the origin IP
 * `UserAuthenticationSuccess` will give you the successful attempts
-  * Google authentication origin will show `sessionId=XXX`
-  * non Google authentication origin will show `clientId=cf`
+  * SSO authentication origin will show `sessionId=XXX`
+  * UAA authentication origin will show `clientId=cf`
 
 ## CPU credits
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -35,7 +35,7 @@
  - [Working practices](team/working_practices/)
  - [Service Targets](team/service_targets/)
  - [Dashboard mac mini](team/dashboard_mac_mini/)
- - [Managing AWS access](team/managing_aws_access/)
+ - [Managing access to Cloud Services](team/managing_access_to_cloud_services/)
  - [Our networking in AWS](team/networking_in_aws/)
  - [How to notify tenants](team/notifying_tenants/)
  - [Our orgs on the paas](team/our_orgs_on_the_paas/)

--- a/source/team/managing_access_to_cloud_services.html.md
+++ b/source/team/managing_access_to_cloud_services.html.md
@@ -36,7 +36,7 @@ We have 4 separate projects:
 
 # Microsoft Azure
 
-We use Microsoft Azure for single sign-on. We log into Azure using the [Azure
+We use Microsoft Azure to provide single sign-on for some tenants. We log into Azure using the [Azure
 Portal](https://portal.azure.com).
 
 We have 4 separate Active Directory apps under the

--- a/source/team/managing_access_to_cloud_services.html.md
+++ b/source/team/managing_access_to_cloud_services.html.md
@@ -1,22 +1,61 @@
-# IAM
+# AWS
+## IAM
 
 Each AWS account has [root account](http://docs.aws.amazon.com/general/latest/gr/root-vs-iam.html) credentials, which we don't use.
 
 Instead we access AWS resources using [IAM](http://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html).
 
-## IAM Roles for VMs
+### IAM Roles for VMs
 
 We use [IAM roles](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) via [intance profiles](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) on our EC2 instances to delegate particular restricted permissions to processes running on those instances.
 
-## IAM Roles for Humans
+### IAM Roles for Humans
 
 We use separate IAM roles for users on our team to use via AWS' assume-role
 feature. See the [RE manual](https://reliability-engineering.cloudapps.digital/iaas.html#access-aws-accounts)
 for details on how to do this.  The available role ARNs that you'll need for
 this are documented [in paas-aws-account-wide-terrafom here](https://github.com/alphagov/paas-aws-account-wide-terraform/blob/master/doc/assume_role_arns.md)
 
-## Role configuration
+### Role configuration
 
 We manage all these IAM roles, and the corresponding policies using Terraform.
 The config is in the [account-wide-terraform](https://github.com/alphagov/paas-aws-account-wide-terraform)
 repo. This includes defining who is allowed to assume the above roles.
+
+# Aiven
+
+We use Aiven for our Elasticsearch backing service.  We log in to Aiven using
+the [Aiven Console](https://console.aiven.io/).
+
+We have 4 separate projects:
+
+- Dev
+- CI
+- Staging
+- Prod
+
+# Microsoft Azure
+
+We use Microsoft Azure for single sign-on. We log into Azure using the [Azure
+Portal](https://portal.azure.com).
+
+We have 4 separate Active Directory apps under the
+digital.cabinet-office.gov.uk Azure account:
+
+- Dev
+- Staging London
+- Prod London
+- Prod
+
+# Google Cloud
+
+We use Google Cloud for single sign-on. We log into Google using the [Google
+Cloud Console](https://console.cloud.google.com/).
+
+We have 2 separate projects under the digital.cabinet-office.gov.uk Azure
+account:
+
+- [GOV.UK PaaS](https://console.cloud.google.com/home/dashboard?project=govuk-paas)
+- [paas-development](https://console.cloud.google.com/home/dashboard?project=paas-development-210707)
+
+Our single sign-on apps are managed in [`GOV.UK PaaS`](https://console.cloud.google.com/apis/credentials?folder=&organizationId=&project=govuk-paas)

--- a/source/team/rotating_credentials.html.md
+++ b/source/team/rotating_credentials.html.md
@@ -65,7 +65,7 @@ Google has two credentials: `client_id` and `client_secret`
 Microsoft functionally has three credentials `client_id`, `client_secret`, and
 `tenant_id`, however `tenant_id` is not secret, we just store it as such.
 
-UAA is not able of consuming multiple pairs of `client_id` and `client_secret`.
+UAA is not capable of consuming multiple pairs of `client_id` and `client_secret`.
 Rotating these credentials will briefly prevent users from signing in to GOV.UK
 PaaS using single sign-on via the IDP with credentials currently being rotated.
 

--- a/source/team/rotating_credentials.html.md
+++ b/source/team/rotating_credentials.html.md
@@ -55,6 +55,24 @@ The following is a diagram of the steps of our CA rotation process. The thick ar
 
 <p><a href="/diagrams/ca-cert-rotations.jpg" target="_blank" rel="noopener noreferrer"><img src="/diagrams/ca-cert-rotations.jpg" alt="Illustration of the CA and certificate YAML fields being moved around by this process" /></a></p>
 
+#### Rotating SSO IDP keys
+
+We use single sign-on using Google and Microsoft to allow our tenants to sign
+in, without using a username and password stored in UAA.
+
+Google has two credentials: `client_id` and `client_secret`
+
+Microsoft functionally has three credentials `client_id`, `client_secret`, and
+`tenant_id`, however `tenant_id` is not secret, we just store it as such.
+
+UAA is not able of consuming multiple pairs of `client_id` and `client_secret`.
+Rotating these credentials will briefly prevent users from signing in to GOV.UK
+PaaS using single sign-on via the IDP with credentials currently being rotated.
+
+Rotating these credentials requires changing the values in `paas-credentials`
+and running the `upload-{google,microsoft}-oauth-secrets` Make tasks and then
+running `create-cloudfoundry`.
+
 ### AWS keys generated in the pipeline
 
 The deployer Concourse has a job for triggering the rotation of AWS keys generated in the pipeline. These keys currently include:


### PR DESCRIPTION
What
----

I have refactored the "Manage access to AWS" to be "Manage access to Cloud services" and added non-exhaustive info about

- Google Cloud
- Aiven
- Microsoft Azure

I have also added some very light documentation about rotating UAA SSO OAuth credentials.

How to review
-------------

`bundle install && rake build && (cd build && python -m http.server)`
`open http://localhost:8000`

Who can review
--------------

Not @tlwr
