### PR TITLE
Make Zendesk tags explicit about backing service

### DIFF
--- a/source/support/zendesk.html.md
+++ b/source/support/zendesk.html.md
@@ -42,7 +42,11 @@ We use the following tags to categorise support tickets:
 | Backing services | govuk_paas_backing_services_binding_unbinding_issues |
 | Backing services | govuk_paas_backing_services_private_beta_access |
 | Backing services | govuk_paas_backing_services_connecting_issues |
-| Backing services | govuk_paas_backing_services_database_backing_service |
+| Backing services | govuk_paas_backing_services_postgres |
+| Backing services | govuk_paas_backing_services_mysql |
+| Backing services | govuk_paas_backing_services_redis |
+| Backing services | govuk_paas_backing_services_elasticsearch |
+| Backing services | govuk_paas_backing_services_cdn |
 | Backing services | govuk_paas_backing_services_performance |
 | Backing services | govuk_paas_backing_services_scaling |
 | Notifications | govuk_paas_notifications_security_cve |


### PR DESCRIPTION
What
----

I want a tag for the cdn broker, but there isn't one at the moment. It would be better to have tags for the individual services we're using.

How to review
-------------

Check the tags

Who can review
--------------

Not @richardTowers , doesn't need 2i or comms approval since this is internal documentation.