### PR TITLE
Clarify user management

### DIFF
--- a/source/support/CF_UAA_user_management.html.md
+++ b/source/support/CF_UAA_user_management.html.md
@@ -86,7 +86,9 @@ The endpoint also works for UAA GUIDs:
 
 ## Locking a user account
 
-Sometimes it might be necessary to lock certain users. For example when we find out they have left GDS or don't have any more project to work on PaaS. CF has a facility to prevent users from logging in, while still preserving the user account with all their access rights and org membership. We do this as a first step in removing the user account. We then ask for confirmation from org managers (or managers of org managers in case we are removing an org manager) and only after confirmation finally remove the account completely (`cf delete-user`).
+Sometimes it might be necessary to lock certain users. For example when we find out they have left GDS or aren't working on any more projects hosted on PaaS.
+
+CF has a facility to prevent users from logging in, while still preserving the user account with all their access rights and org membership.
 
 From [alphagov/paas-cf](https://github.com/alphagov/paas-cf):
 
@@ -98,29 +100,16 @@ TARGET=$(cf curl /v2/info | jq -r .token_endpoint) \
   bundle exec ./uaa_lock_user.rb <USERNAME>
 ```
 
-## Finding out org membership
+## Deleting user accounts
 
-In order to notify the org manager of a given user, we need to find out who that would be. UAA does not know which org/space user belongs to. This information is only available to cloud controller: `cf curl /v2/users/<uaa_user_id>/summary`
+UAA, CF, and the PaaS Accounts microservice each hold partial information about users.
 
-The user summary contains all orgs and spaces they are member of. It also contains the UAA ID of managers of these. To get user name from UAA id, simply: `bundle exec uaac curl /Users/<uaa_user_id> | grep userName`
+To minimise edge cases around user management, we should not delete users from
+any individual microservice, unless absolutely necessary, in which case we
+should delete the user from all microservices.
 
-## Notifying the org manager
-
-Send an email from support email address: `gov-uk-paas-support@digital.cabinet-office.gov.uk`. Example email:
-
-```
-Hi <org manager 1st name>,
-
-We have noticed that <user name of disabled account> was inactive <describe how we found out, e.g. when we tried to send him email and it got bounced>. We wondered if perhaps this person has left GDS. We have noticed this user still has an account in `<org name>` organization and `<space name(s)>` space. We have disabled this user for now.
-
-Can you please confirm if we can remove the user entirely, or instead if the user is still expected to have access to the PaaS?
-
-
-Thanks,
-PaaS for Government
-```
-
-When they respond support can follow up with user deletion, or instead enable the user account again if it is to be actively used.
+Locking a user account and removing all user permissions is enough to disable a
+user's access.
 
 ## Global Auditor role
 
@@ -133,12 +122,6 @@ To add someone:
 
 ```
 bundle exec uaac member add cloud_controller.global_auditor <EMAIL>
-```
-
-To remove someone:
-
-```
-bundle exec uaac member delete cloud_controller.global_auditor <EMAIL>
 ```
 
 To see the current members:


### PR DESCRIPTION
What
----

After the SSO work we have state split across multiple microservices, in
a way which is difficult to reconcile.

We don't delete users when we do leavers tickets, instead just lock them
and remove all their user permissions.

This should be in the team manual.

How to review
-------------

Read it
