### PR TITLE
Update our docs on sending buildpack emails

### DIFF
--- a/source/guides/upgrading_CF,_bosh_and_stemcells.html.md
+++ b/source/guides/upgrading_CF,_bosh_and_stemcells.html.md
@@ -72,9 +72,25 @@ You should test the upgrade changeset:
 
 ### Buildpacks
 
+Buildpack upgrades are typically done as a separate story. You should upgrade the buildpacks to at least the versions included in the cf-deployment version currently deployed.
+
 We have to a give at least a week's notice to tenants about the buildpack upgrades, so prepare the version changes separately from the CF component upgrades.
 
-Buildpack upgrades are typically done as a separate story. You should upgrade the buildpacks to at least the versions included in the cf-deployment version currently deployed.
+There is a (semi-)automated process for upgrading buildpacks, which includes generating the email:
+
+The developer does the following:
+
+* In paas-cf run `scripts/update_buildpacks.sh` to update our cache of buildpack dependencies
+* Commit the changes to a branch
+* Raise a PR for the changes and move the story into review
+
+The reviewer does the following:
+
+* Run `scripts/create_buildpacks_email.sh` to create the email
+* Send the email using the [google group interface] with the subject "GOV.UK PaaS - Upcoming buildpack upgrades - $DATE", where $DATE is in the format "11th September 2019"
+* Mark the story as blocked with a blocker in the form `until 2019/09/11`
+* Wait until the given date, then merge the PR to upgrade the buildpacks
+
 
 ## Notify the tenants
 

--- a/source/team/notifying_tenants.html.md
+++ b/source/team/notifying_tenants.html.md
@@ -108,15 +108,9 @@ The body should contain:
 
 ### CF buildpack emails
 
-Use the latest "GOV.UK PaaS - Upcoming buildpack upgrades" email in the
-gov-uk-paas-announce [google group interface] as an example.
-
-You'll need to produce a summary of changes between the old and new buildpacks,
-which is a bit of a tedious manual process. See
-[operations.d/240-cf-set-buildpack-release.yml](https://github.com/alphagov/paas-cf/blob/master/manifests/cf-manifest/operations.d/240-cf-set-buildpack-release.yml)
-for the pinned versions and the GitHub releases pages for the buildpacks (e.g.
-[cloudfoundry/binary-buildpack/releases/v1.0.21](https://github.com/cloudfoundry/binary-buildpack/releases/v1.0.21))
-to read about the changes.
+We generate our buildpack notification emails using the (semi-)automated
+process described in [the documentation about upgrading
+buildpacks](/guides/upgrading_CF,_bosh_and_stemcells/#buildpacks).
 
 **NB Incident comms email templates are saved in Statuspage.**
 


### PR DESCRIPTION
What
----

We got this slightly wrong this time, as we didn't run
`./scripts/update_buildpacks.sh`, so we were missing dependency
information in the email.

Adding some documentation that isn't incorrect might help us avoid this
mistake in future.

How to review
-------------

* Review the docs

Who can review
--------------

Not @richardtowers