### PR TITLE
[#168263529] make dev credhub is preferred over showenv

### DIFF
--- a/source/team/dashboard_mac_mini.html.md
+++ b/source/team/dashboard_mac_mini.html.md
@@ -59,4 +59,4 @@ We use the [Super Auto Refresh](https://chrome.google.com/webstore/detail/super-
 
 We have created a [dashboard in Grafana, called 'User Impact - prod'](https://grafana.cloud.service.gov.uk/d/paas-user-impact/user-impact-prod?refresh=5s&orgId=1) and [dashboard in Grafana, called 'User Impact - prod-lon'](https://grafana.london.cloud.service.gov.uk/d/paas-user-impact/user-impact-prod-lon?refresh=5s&orgId=1), which displays a count of monitors by trigger status (healthy, warning, critical, or unknown) for each production environment.
 
-The credentials for the Grafana mon users can be found by running `make <env> showenv` from paas-cf.
+The credentials for the Grafana mon users can be found by running `make <env> credhub` from paas-cf.


### PR DESCRIPTION
What
----
We are migrating to a world where `make dev showenv` in `paas-cf` no longer spews secrets all over an operators screen. This commit tells readers to use the preferred `make <env> credhub` instead.

How to review
-------------
1. Copy review

Who can review
--------------
Anyone