### PR TITLE
Update new incident process and roles and responsibilities.

### DIFF
--- a/source/incident_management/incident_process.html.md.erb
+++ b/source/incident_management/incident_process.html.md.erb
@@ -5,110 +5,126 @@ This section summarises :
 - how to manage incidents and outages to ensure a highly available service
 - how to manage incident comms
 
+You may refer to [Support roles and responsibilities](/support/roles_and_responsibilities/) for information on support rota, roles and responsibilities for in hour, out of hour engineers and Techops RE Incident Escalation.
+
 <%= warning_text('
 	<p>Reevaluate the information you have throughout an incident in a security context.</p>
 	<p>If you suspect a security breach, <a href="/support/responding_to_security_issues/#if-you-suspect-a-security-breach">alert Information Assurance (IA) immediately</a>.</p>
 	') %>
 
 
+## In hours incident process
+For incidents which occur during the working day, the in hours support lead should begin by investigating the incident and assessing the severity. If needed, the support lead should request one other person from the team to act as communications lead. Depending on the severity of the incident, they should also request more support from other members of the PaaS team. **Incidents take priority over BAU work**. 
 
-## Set up the incident team
 
-When an incident happens, the person on support must:
+### Investigate and resolve the incident
+Your responsibility depends on your role within the ‘incident team’:
 
-- nominate an incident lead; this person must have production access, and may be the person on support
-- nominate an incident comms person; during out-of-hours this can be the person on the PaaS escalation rota
-- join #paas-incident on Slack if required
+#### In hours support lead (incident lead)
+1. Investigate the incident and request additional help if required.
+1. Decide on the incident [severity level](/support/support_manual/#severity-levels).
+1. Make necessary changes to the production environment (only the incident lead should do this).
+1. Record actions taken and changes made in the #paas-incident Slack channel.
+1. Discuss the incident with the PaaS product and delivery managers to decide when the incident is resolved or can be downgraded as it is no longer impacting the service.
 
-The incident lead, incident comms person and anyone else needed to work on the incident will form the incident team.
+#### Incident comms lead
+1. Let the PaaS team know about the incident on #paas-incident Slack channel.
+1. Notify the tenants about the investigation by creating a new incident in [Statuspage](/team/statuspage/) using the ‘Possible issue being investigated’ template. 
+**Important: when creating or updating an incident you must tick the boxes to say which components are affected, otherwise notifications will not be sent.**
+3.   Update tenants regularly using the [saved templates](https://manage.statuspage.io/login?redirect=%2Fpages%2Fh4wt7brwsqr0) in our [Statuspage](https://team-manual.cloud.service.gov.uk/team/statuspage/) account. The severity level page shows how frequently you should update tenants.
 
-Incident team leads can request support from any other members of the PaaS team. Incidents take priority over BAU, for example retrospectives or planning sessions.
+Between them, the incident lead and comms lead should make a decision as to whether the incident needs to be escalated further. Their first point of call should be the GOV.UK PaaS Product Manager. 
 
-## Investigate and resolve the incident
+### When the incident is over
 
-Your incident responsibilities depend on your role within the incident team.
+When the problem has been fixed, check that our [Statuspage](/team/statuspage/) is showing that the PaaS is operational. Note on #paas-incident channel that the issue is resolved.
 
-### Incident lead
-
-1. Investigate the incident, requesting help from PaaS team if required.
-
-1. Make necessary changes to the production environment (only the incident lead can do this).
-
-1. Record actions taken and changes made in the #paas-incident slack channel.
-
-1. Discuss the incident with the PaaS product and delivery managers to decide when the incident is resolved, or can be downgraded as it is no longer impacting the service.
-
-As a lower priority, create a pivotal story to record all actions taken and identify any ongoing work.
-
-### Incident comms
-
-1. Let the PaaS team know about the incident on the #paas Slack channel.
-
-1. Notify the tenants about the investigation by creating a new incident in [Statuspage](https://team-manual.cloud.service.gov.uk/team/statuspage/) using the “Possible issue being investigated” template. 
-
-    > __Important__: When creating or updating an incident, you must tick the boxes to say which components are affected, otherwise notifications will not be sent.
-
-1. Update tenants hourly using the [saved templates](https://manage.statuspage.io/pages/h4wt7brwsqr0) in our Statuspage account.
-
-## Escalations
-
-You can escalate incidents within the GOV.UK PaaS team.
-
-1. Go to [PagerDuty](https://governmentdigitalservice.pagerduty.com/services).
-
-1. Go to __Configuration__ and select [__Schedules__](https://governmentdigitalservice.pagerduty.com/schedules).
-
-1. Check who is currently on the escalation rota.
-
-1. Go back to __Configuration__ and select [__Users__](https://governmentdigitalservice.pagerduty.com/users).
-
-1. Select the relevant person to find their phone number.
-
-If you need to escalate an incident beyond the GOV.UK PaaS team, contact these people in the following order:
-
-* Head of Reliability Engineering
-* TechOps Programme Director
-
-The person contacted will decide if they need to alert a member of the GDS executive group. 
-
-If neither the TechOps Programme Director nor the Head of Reliability Engineering are available, you must contact the Director for GDS Portfolio Group.
-
-The contact details for the above people, as well as useful contacts, can be found in [PaaS Emergency contacts and escalations (restricted access)](https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/1_6zxOjvwY-zrf1D8eDNT9AeRhlcPAocBhC8dmHfRw0Y/edit?usp=sharing)
-
-## When the incident is over
-
-When the problem has been fixed, check that our [status page](https://status.cloud.service.gov.uk/) is showing that the PaaS is operational.
-
-### Write the incident report
-
+#### Write the incident report
 The incident lead and incident comms must write the incident report, ensuring that all relevant details, decisions and comms are in the timeline section of the report.
 
-The [incident report template](https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/155yrsyhHM9Feh-ucxLzyj7toIb2sMK8KiGVdEFLcyfQ/edit?usp=sharing) provides guidance about how to complete it.
+The [incident report template](https://docs.google.com/document/d/155yrsyhHM9Feh-ucxLzyj7toIb2sMK8KiGVdEFLcyfQ/edit) provides guidance about how to complete it. 
 
-### Hold an incident review meeting
+#### Hold an incident review meeting
+Conduct a no-blame retro of the incident within one week of resolving the incident in order to:
 
-Conduct a [no-blame retro](https://codeascraft.com/2012/05/22/blameless-postmortems/) of the incident within one week of resolving the incident to:
+* Agree on what happened
+* Ensure the record fully reflects this
+* Agree all follow-up actions
 
-- agree on what happened
-- ensure the record fully reflects this
-- agree all follow-up actions
+Invite the following people to the retro:
 
-Invite the following people:
+* Incident lead
+* Incident comms
+* Delivery Manager
+* Product manager
+* Technical Architect
+* Anyone else who had any involvement in the incident
 
-- Incident Lead
-- Incident Comms
-- Incident team
-- Delivery manager
-- Product Manager
-- Technical Architect
+Write Pivotal stories for any actions which have come out of the incident.
 
-### Publish the incident report
 
-Incident comms creates a version of the incident report for publication. Refer to the [template](https://drive.google.com/open?id=1g2_KVXfZnBDVFFlxyModAi8YSbF0uun32Z1Pe5TYBc8) for guidance, and also see previous examples.
+## Publish the incident report
 
-By default we publish Incident Reports on Statuspage unless there is a good reason not to. It sets a good example and demonstrates openness. 
+The incident comms lead should create a version of the incident report for publication. Refer to the [template](https://docs.google.com/document/d/1g2_KVXfZnBDVFFlxyModAi8YSbF0uun32Z1Pe5TYBc8/edit) for guidance, and also see previous examples.
 
-The only incidents for which this is not automatically true are for security incidents which need to be carefully considered  to ensure that no further harm could be caused by publishing these.
+By default we publish Incident Reports on [Statuspage](/team/statuspage/) unless there is a good reason not to. It sets a good example and demonstrates openness.
+
+The only incidents for which this is not automatically true are for security incidents which need to be carefully considered to ensure that no further harm could be caused by publishing these.
+
+
+## Out of hours incident process
+### Step one - Preliminary investigation (max. 15 minutes)
+
+Carry out enough investigation to confirm that there really is an issue and what the priority is (according to the [severity levels](/support/support_manual/#severity-levels)). For P1 incidents, contact the **Techops RE Incident Escalation** person if you need help for communication so that you can focus on investigating the incident:
+
+1. Go to [PagerDuty](https://governmentdigitalservice.pagerduty.com/services).
+1. Under teams, select GOV.UK PaaS.
+1. Go to **Configuration** and select [Schedules](https://governmentdigitalservice.pagerduty.com/schedules).
+1. Check who is currently on the **Techops RE Incident Escalation** rota.
+1. Go back to **Configuration** and select [Users](https://governmentdigitalservice.pagerduty.com/users).
+1. Select the relevant person to find the phone number.
+
+For all other incidents update [Statuspage](https://team-manual.cloud.service.gov.uk/team/statuspage/) and #paas-incident yourself, and then wait until working hours to investigate further.
+
+
+### Step two - Investigate and resolve the incident
+
+If you are paged out of hour as the on-call engineer, you will become the incident lead and incident comms. You may decide to escalate to Techops RE Incident Escalation, in that case, the escalation person will be responsible for incident comms.    
+
+#### Incident lead (on call engineer)
+
+1. Investigate the incident.
+1. If deemed necessary, contact the TechOps RE Incident Escalation person to get comms support.
+1. Make necessary changes to the production environment (only the incident lead can do this).
+1. Record actions taken and changes made in the #paas-incident slack channel.
+1. Discuss the incident with the communication escalations person to decide when the incident is resolved or can be downgraded as it is no longer a P1 incident.
+1. Update the #paas-incident slack channel to state it is no longer a P1 incident.
+
+#### Incident comms (on call engineer or Techops RE Incident Escalation)
+1. Notify tenants about the investigation by creating a new incident in [Statuspage](/team/statuspage/) using the ‘Possible issue being investigated’ template.
+1. Let the PaaS team know about the incident on the #paas-incident slack channel.
+1. Update tenants hourly using the [saved templates](https://manage.statuspage.io/login?redirect=%2Fpages%2Fh4wt7brwsqr0) in our Statuspage account.
+1. The Techop escalation rota is the final decision point. 
+
+
+Useful contact details can be found in [PaaS Emergency contacts and escalations (restricted access)](https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/1_6zxOjvwY-zrf1D8eDNT9AeRhlcPAocBhC8dmHfRw0Y/edit?usp=sharing)
+
+#### When the incident is over
+When the problem has been fixed, check that our [Statuspage](/team/statuspage/) is showing that the PaaS is operational.
+
+Ensure that #paas-incident is updated to show the incident is over.
+
+### The next working day
+Using the information documented in the #paas-incident channel, create a Pivotal story to record all actions taken and identify any ongoing work. 
+
+Continue as per the [in hours](/incident_management/incident_process/#when-the-incident-is-over) process.
+
+### If the out of hours support engineer does not respond
+In the event that the out of hours support engineer doesn’t respond to the Pagerduty alert within 30 minutes of being notified, Pagerduty will then automatically contact the TechOps RE Incident Escalation rota. The escalation person will then need to reach out to another engineer to try and resolve the issue. If the TechOps RE Incident Escalation doesn’t respond to the alert within 30 minutes, Pagerduty will automatically alert all members of the out of hours support rota by email. 
+
+In the event that you are contacted but aren’t scheduled to be on the rota, your first point of call should be to check the #paas-incident Slack channel to see if another engineer has already picked it up. If no one has, leave a message to state that you are beginning to investigate. 
+
+
 
 ## Suppliers
 
@@ -124,3 +140,7 @@ Aiven monitors its services 24 hours a day 365 days a year, and provides free em
 - rapidly address any issues in system operations requiring manual intervention
 
 Responses are provided on a best-effort basis during the same or next business day. Email [support@aiven.io](mailto:support@aiven.io) for all support requests.
+
+### Other Important contacts in Reliability Engineering
+
+You can refer to [RE On-call escalation](https://re-team-manual.cloudapps.digital/documentation/re-oncall-escalation-info.html#important-contacts) for other important contacts that may be relevant, including Cyber Security. 

--- a/source/support/roles_and_responsibilities.html.md
+++ b/source/support/roles_and_responsibilities.html.md
@@ -2,59 +2,56 @@
 
 What each role does on support and when it's needed.
 
+You can refer to [Incident Process](/incident_management/incident_process/) for information on How to manage incidents and incident communication.
+
 ## Rota
+
 The support rota is on [Pagerduty](https://governmentdigitalservice.pagerduty.com/schedules).
 
-For in-hours support, one person from the team will be the Support Lead on a weekly basis. For out of hours support, to begin with, we will have one person from the team on call as Support lead, again on a weekly basis. We will also have a second person on call for Escalations.
+There are three separate rotas; in hours, out of hours and TechOps RE Incident Escalation.
 
-If you are on in-hours support, add your shift onto the #paas slack channel description so your colleagues find it easier to see who is on support. If you need to swap shifts, ask your colleagues if they can swap or cover, update Pagerduty [using an override](https://support.pagerduty.com/hc/en-us/articles/202830170-Creating-and-Deleting-Overrides).
+If you are on support, add your shift onto the #paas slack channel description so your colleagues can see who is on support and that you are currently looking at the issue. If you need to swap shifts, ask your colleagues if they can swap or cover, then [update Pagerduty using an override](https://support.pagerduty.com/hc/en-us/articles/202830170-Creating-and-Deleting-Overrides).
 
-## Expectations
-The broad response times and action that our users expect from us are documented in the [PaaS Support Overview (Gdoc)](https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/1FLiKPmM61ikO1MJNo96YpxGaYPUMb8CdAcWPnzBBa0U/edit?usp=sharing), and [Product pages](https://www.cloud.service.gov.uk/support.html). Please read it so you know what they expect. These expectations are different for in-hours and out of hours support.
 
-## In-hours
-For in-hours support, if you need to take a break for lunch or essential meetings etc, make sure you tell people ahead of time, and arrange for a colleague to cover for you. All other members of the team are responsible for providing assistance to the support person as needed. If you don’t feel comfortable asking your colleagues, talk to the delivery manager or team lead who can help.
+## In hours support role and responsibility
+The in hours support lead is responsible for:
 
-## Out of hours
+* monitoring system alerts and system health
+* recording the number and nature of build fails on pivotal (label: fixing the build) so we can identify higher impact/frequency ones
+* ensuring that each ticket in ZenDesk is picked up and responded to appropriately
+* initial triage - providing or confirming the initial assessment of priority - there may be some discussion with the initiator (tenant) required here to clarify impact.
+* involving other people as needed - supported by the delivery or product manager
+* assigning an incident lead if the item is an incident.
+* picking up ‘small tasks’ in Pivotal if there is time in between support tasks
+* having a support handover meeting at the beginning and end of the support week
+
+When you need to take a break for lunch or essential meetings etc, make sure you tell people ahead of time, and arrange for a colleague to cover for you. All other members of the team are responsible for providing assistance to the support person as needed. If you don’t feel comfortable asking your colleagues, talk to the delivery manager or team lead who can help.
+
+
+## Out of hours support role and responsibility
+
+The out of hours support engineer is responsible for:
+
+* Responding to system alerts which will be sent to you via pagerduty. These will only be things which seriously impact the availability of live services due to a problem with our platform.
+* Responding to notification from tenant teams of P1 issues they are having which are caused by problems with the PaaS. This will also be via Pagerduty.
+* Looking at the issue and telling the initiator that you are doing so (if initiated by a human).
+* Doing what is needed to ensure the platform is available, not necessarily fixing or diagnosing the root cause.
+* Alerting the communication escalation person if they feel they need support with putting out tenant comms.
+* Involving other people if needed. NO HEROICS, do not deploy if unsure. Some things are not a one-person-decision.
+
 For out of hours similar guidelines apply, if you need cover for an hour or two or an evening (e.g. for an appointment, or a family dinner), you need to agree this in advance with a colleague who can cover for you, and [update Pagerduty using an override](https://support.pagerduty.com/hc/en-us/articles/202830170-Creating-and-Deleting-Overrides).
-
-When we first start out of hours support we’ll be in private beta and have few live services which need OOH. These services know that we are learning about OOH, and will not be as polished as we will be later.
-
-## Bank Holidays
 
 On a Bank Holiday, we create a daytime override on the out-of-hours schedule so there is someone on the rota during Bank Holiday daytime. This person is usually the current out-of-hours person. We also create an override on the in-hours schedule to ensure that any alerts go to PaaS team email rather than the in-hours person.
 
-## In-hours responsibilities
-The In hours Support Lead is responsible for
+## TechOps RE Incident Escalation role and responsibility
+This person will only be alerted if the out of hours 1st line support has decided that they need help with tenant communications so they can focus on fixing the issue. Or if the 1st line support does not answer the alert for 30 mins, pagerduty will automatically call this rota. They will then be responsible for:
 
-* monitoring system alerts and system health, and recording any issues in ZenDesk
-* recording the number and nature of build fails on pivotal (label: fixing the build) so we can identify higher impact/frequent ones
-* ensuring that each ticket in ZenDesk is picked up and responded to appropriately
-* assigning /starting work on tickets and telling the initiator that you are doing so
-* initial triage - providing or confirming the initial assessment of priority  - there may be some discussion with the initiator (tenant) required here to clarify impact.
-* involving other people as needed - supported by the delivery or product manager
-* assigning an incident lead if the item is an incident.
-* working on [other items (Gdoc)](https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/167ymOJmv1zXCPK8UUoW4P_zUKvv9qr96oBioXXnNK5o/edit?usp=sharing) while not responding to alerts (NOTE items should be kicked off and have tickets/cards the same as any other work)
-* noting what they have done in a [support week document (Gdoc)](https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/1tC5G48uHnlu-qK9oGGx85QrArZSJRuFNKV2kKtFsVck/edit?usp=sharing) which lives in the [weeknotes folder](https://drive.google.com/drive/folders/0B3dxtmub3df5WmMtWnZJSi1VcXc?usp=sharing_)
-* having a support handover meeting at the beginning and end of the support week
+* Making decisions and sending out tenant communications (if appropriate). This includes Slack [#paas-incident](https://gds.slack.com/messages/CAD4W35KK) channel, and [Statuspage](/team/statuspage/).
+* To act as an automatic escalation if an on-call engineer fails to respond to an incident. If this happens the escalation person is responsible for finding someone from the team who can respond to the incident. Pagerduty will only trigger an alert if there are issues seriously impact the availability of the live services running on PaaS. The Escalation person will not be expected to fix the problem, just ensure that it is being handled appropriately.
+* To provide leadership-level backup for RE on-call engineers if an incident requires leadership decision making or a broader response involving updating comms or activating other engineers.
 
-## Out-of-hours responsibilities
-The Out of hours Support Lead is responsible for
 
-* Responding to system alerts which will be sent to you via pagerduty. These will be things which seriously impact the availability of live services due to a problem with our platform
-* Responding to notification from tenant teams of P1 issues they are having which are caused by problems with the PaaS. This will also be via Pagerduty.
-* Looking at the issue and telling the initiator that you are doing so (if initiated by a human)
-* Doing what is needed to ensure the platform is available, not necessarily fixing or diagnosing the root cause.
-* Telling the escalation person if we need to put out tenant comms before morning.
-* Involve other people if needed NO HEROICS, do not deploy if unsure. Some things are not a one person decision
-* Noting what has been done in a [support week document (Gdoc)](https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/1tC5G48uHnlu-qK9oGGx85QrArZSJRuFNKV2kKtFsVck/edit?usp=sharing)
-* Having a support handover meeting at the beginning and end of the support week
+You can find more information on the PaaS [incident Process](/incident_management/incident_process/#incident-process).
 
-## Escalations responsibilities
-The Escalations Out of hours person is responsible for
+You can also refer to [Reliability Engineering on-call escalation](https://re-team-manual.cloudapps.digital/documentation/re-oncall-escalation-info.html#reliability-engineering-on-call-escalation) section in the RE team manual for descriptions of the escalation roles and responsibility in Reliability Engineering. 
 
-* Responding to system alerts which will be sent to you via pagerduty if the OOH support lead is unable to deal with them. These will be things which seriously impact the availability of live services due to a problem with our platform.
-* Making decisions about and sending any tenant comms during OOH.
-* Escalating outside the team (through GDS) if required. More on this in the [Incident Process](/incident_management/incident_process/#incident-comms)
-* noting what has been done in a [support week document](https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/1tC5G48uHnlu-qK9oGGx85QrArZSJRuFNKV2kKtFsVck/edit?usp=sharing_)
-* having a support handover meeting at the beginning and end of the support week

--- a/source/team/notifying_tenants.html.md
+++ b/source/team/notifying_tenants.html.md
@@ -10,7 +10,7 @@ Depending on what it is we want to tell users, we have three different channels 
 
 ## Sending incident alerts and updates
 
-Follow the guidance in [this section](/incident_management/incident_process/#incident-comms) of the team manual if you're managing incident comms and you need to send alerts and updates to tenants.
+Follow the guidance in [this section](/incident_management/incident_process/#incident-comms-lead) of the team manual if you're managing incident comms and you need to send alerts and updates to tenants.
 
 ## Sending platform change and new feature announcements
 


### PR DESCRIPTION
What
----
Updated the team manual to reflect 
- new incident management process
- new roles and responsibility to include Techops RE incident escalation
- Amended a broken link in notifying tenants page.  


How to review
-------------
Review the contents:
- All the link still work in the pages changed
- The headers are of correct level
- Generally double checking content and formatting are correct. 


Describe the steps required to test the changes.

Who can review
--------------
Anyone from the PaaS team. 

