### PR TITLE
[#171180051] Document how to rotate broker passwords

### DIFF
--- a/source/team/rotating_credentials.html.md
+++ b/source/team/rotating_credentials.html.md
@@ -74,6 +74,28 @@ To perform the rotation:
 1. Unpause the `create-cloudfoundry` pipeline
 1. Trugger the `create-cloudfoundry` pipeline and allow it to run to completion
 
+### Rotating broker credentials
+
+Our service brokers have basic auth in front of them to ensure that only we
+can communicate with them. Unfortunately our brokers do not support swapping
+credentials without downtime.
+
+In the `create-cloudfoundry` pipeline, under the `credentials` tab, there
+is a `rotate-broker-credentials` job. Rotating the broker credentials is a
+two step process:
+
+1. Run the `rotate-broker-credentials` job to update the credentials in Credhub.
+2. Run the main `create-cloudfoundry` job to apply the new credentials.
+
+There will be downtime between when the pipeline redeploys the brokers and
+when it updates the broker credentials to be used by Cloud Controller. For
+information on what happened the first time, and how to communicate this to
+tenants, see https://status.cloud.service.gov.uk/incidents/3qll54zh55zk.
+
+At the time of writing this only rotates the basic auth used to talk to the
+brokers. It does not rotate other difficult secrets, such as those used to
+generate passwords for service instances.
+
 ### Rotating CA and leaf certificates
 
 We rotate CA and leaf certificates automatically as part of the `create-cloudfoundry`


### PR DESCRIPTION
What
----

CVE-2020-5400 leaked the basic auth credentials of some our brokers. We played Pivotal Tracker story #171180051 to rotate those credentials. It added a new pipeline job. Unlike our other credential rotation processes this one involved downtime because our brokers lack support for changing basic auth credentials without downtime.

This commit documents the process so that we retain knowledge. I'm most keen to have documented what this new job doesn't do: it only rotates the basic auth credentials, not anything else. That is important context to retain.

How to review
-------------

Read through the documentation changes and see if you have all your questions answered.

Who can review
--------------

Not @46bit.