### PR TITLE
Update links to support & signup forms

### DIFF
--- a/source/accounts/account_lifecycle.html.md
+++ b/source/accounts/account_lifecycle.html.md
@@ -5,7 +5,7 @@
 
 Requests to create a new trial org are always handled via Zendesk by the support agent. A range of Zendesk macros are available to speed up the completion of this task.
 
-In most cases, a user will request a trial org by using the form at <https://www.cloud.service.gov.uk/signup>, which triggers an automated Zendesk ticket. Users should be encouraged to use this route.
+In most cases, a user will request a trial org by using the form at <https://admin.london.cloud.service.gov.uk/support/sign-up>, which triggers an automated Zendesk ticket. Users should be encouraged to use this route.
 
 ### When the request doesn't come through the signup form
 

--- a/source/support/zendesk.html.md
+++ b/source/support/zendesk.html.md
@@ -16,7 +16,7 @@ Email notifications of incoming tickets are administered manually. This needs do
 
 ## Routing
 
-The in-hours email address `gov-uk-paas-support@digital.cabinet-office.gov.uk` is given in numerous places, for instance our [Support](https://www.cloud.service.gov.uk/support) page. The out-of-hours email address is deliberately not written down in public, to avoid spam waking people up at night.
+The in-hours email address `gov-uk-paas-support@digital.cabinet-office.gov.uk` is given in numerous places, for instance our [Support](https://admin.london.cloud.service.gov.uk/support) page. The out-of-hours email address is deliberately not written down in public, to avoid spam waking people up at night.
 
 Both email addresses are Google Groups. Originally we used Gmail Aliases but they did not support prepending to email subjects for Zendesk. These groups forward emails elsewhere and are not intended for use by themselves. Their spam protection is disabled to avoid emails being silently discarded.
 


### PR DESCRIPTION
What
----

[We've moved support forms into paas-admin](https://github.com/alphagov/paas-admin/pull/936), so link urls need to be updated.

How to review
-------------

- check url takes you to the correct page

Who can review
--------------

not @kr8n3r 
