### PR TITLE
Update GPG keyserver to `keyserver.ubuntu.com`

### DIFF
--- a/source/guides/GPG.html.md
+++ b/source/guides/GPG.html.md
@@ -48,7 +48,7 @@ The output will look something like the following:
 
 Take the long ID listed after `Key fingerprint =` and run:
 
-    gpg --keyserver pgp.mit.edu --send-keys 'YOUR ID HERE …'
+    gpg --keyserver keyserver.ubuntu.com --send-keys 'YOUR ID HERE …'
 
 You will need to provide the same ID to an existing member of the team so
 that they can add you to any secret stores that you need access to.


### PR DESCRIPTION
What
----

We use keyserver.ubuntu.com as our keyserver in
https://github.com/alphagov/paas-credentials/blob/master/Makefile#L18
and syncing isn't as fast as we'd like, so it makes sense to use the
same keyserver in both places.

How to review
-------------

Code review

Who can review
--------------

Anyone
