### PR TITLE
Fix heading levels for accessibility

### DIFF
--- a/source/architecture_decision_records/ADR025-service-plan-naming-conventions.html.md
+++ b/source/architecture_decision_records/ADR025-service-plan-naming-conventions.html.md
@@ -26,13 +26,13 @@ Where:
 * `LABEL` is a string describing some specific variant of the service if relvent.
 * `VERSION` is the version number of the service plan.
 
-#### For example:
+### For example:
 
 A large multi-az postgres plan for version 9.6 would be `large-ha-9.6`.
 
 A small not multi-az, unclustered, redis 3.2 plan would be `redis-unclustered-3.2`.
 
-#### Example migrations of some existing plans:
+### Example migrations of some existing plans:
 
 ```
 L-HA-enc-dedicated-9.5 => large-ha-9.5
@@ -41,7 +41,7 @@ tiny-clustered => tiny-clustered-3.2
 tiny-unclustered => tiny-unclustered-3.2
 ```
 
-#### Additionally:
+### Additionally:
 
 * We will avoid use of the word "free" in names.
 * We will avoid using redundent words (like 'dedicated') in names to reduce noise.

--- a/source/guides/Tenant_Application_Penetration_Testing.html.md
+++ b/source/guides/Tenant_Application_Penetration_Testing.html.md
@@ -1,7 +1,7 @@
 # Tenant Application Penetration and Load Testing
 
 
-### Penetration testing
+## Penetration testing
 
 We no longer have to notify AWS of penetration testing, however it is useful for the team to know that this is taking place and that we have contact details of the testers if issues arise during the testing window.
 
@@ -17,7 +17,7 @@ We no longer have to notify AWS of penetration testing, however it is useful for
 | emergency_contact | Provided by penetration tester. Email and phone number in case issues arise. |
 
 
-### Load Testing
+## Load Testing
 
 
 Before allowing a load test against applications running on PaaS we may have to notify AWS. Currently we are not sure on the scenarios when we do not have to notify AWS. We are erring on the side of caution and notifying for all load tests.

--- a/source/guides/upgrading_CF,_bosh_and_stemcells.html.md
+++ b/source/guides/upgrading_CF,_bosh_and_stemcells.html.md
@@ -33,7 +33,7 @@ Special differences to take into account:
 * Update the cf-acceptance-tests resource in the pipeline to use an upstream `cfX.Y` branch matching the cf-deployment version.
 * Note: If we are using a forked version of the smoke-tests or cf-acceptance test, create a new branch and rebase our forked version accordingly.
 
-#### Credhub
+### Credhub
 
 _(section added October 2018)_
 

--- a/source/team/comms_lead_role.html.md
+++ b/source/team/comms_lead_role.html.md
@@ -1,6 +1,6 @@
 # Comms lead role - PaaS Incidents
 
-### What to do first:
+## What to do first:
 Learn about [Pagerduty](/team/pagerduty/)
 
 1. Pagerduty calls/alerts you
@@ -9,7 +9,7 @@ Learn about [Pagerduty](/team/pagerduty/)
 1. Make a copy of the [incident report](https://docs.google.com/document/d/1U2F6TLrrKTuDkYCtkW4DXryiaPoGDPmrZ-b2Teibjvo/) name the document and start to fill it in
 1. Record the timeline of events as they happen in the incident report
 
-### Statuspage - creating an incident:
+## Statuspage - creating an incident:
 
 Learn about [Statuspage](/team/statuspage/)
 
@@ -20,10 +20,10 @@ Learn about [Statuspage](/team/statuspage/)
 1. Select 'send notifications' to email tenants. If it’s a small issue, you may not want to send them a notification (in this case, only our status page will be updated)
 1. The subscribers on statuspage will get the notifications
 
-### If you need to escalate to SMT on call:
+## If you need to escalate to SMT on call:
 1. If you need to escalate to SMT (for example, if its affecting coronavirus services) - go to [rotas app](https://rotas.cloudapps.digital/teams/techops-management-escalations) and click on the current on call individual to get their contact info 
 
-### Don’t forget:
+## Don’t forget:
 1. Your aim is to do just enough support out of hours to get through to working hours :)
 1. You can update the x-gov slack paas channel if relevant
 


### PR DESCRIPTION
What
----

Some heading levels were skipped (for example, H1s to H3s), which is an accessibility issue. I fixed them so that levels are no longer skipped.

How to review
-------------

Preview content locally and check that the fixes work and are appropriate

Who can review
--------------

Anyone but @cmcnallygds 