### PR TITLE
Remove link to team manual

### DIFF
--- a/source/guides/common_support_tasks.html.md
+++ b/source/guides/common_support_tasks.html.md
@@ -2,7 +2,6 @@
 
 This guide contains instructions for common support tasks.
 
-The [PaaS Support Manual](https://docs.google.com/document/d/1Ui0MQtZbZnRCIj4RUdqCPU6PdWvfqY9FNf7Ou3OE99w) lives elsewehere, but should be moved into the team manual sometime soon.
 
 ## Changing a user's password
 


### PR DESCRIPTION
What
----

Removed link to outdated team manual

How to review
-------------

Check that content looks OK and that there is no essential info in that team manual which is not replicated elsewhere

Who can review
--------------

Anyone familiar with this team manual and its content
