### PR TITLE
guides: add guide on testing alertmanager

### DIFF
--- a/source/guides/test_alertmanager.html.md
+++ b/source/guides/test_alertmanager.html.md
@@ -1,0 +1,107 @@
+# Testing Alertmanager
+
+This is a guide to testing Alertmanager
+
+We use Alertmanager for broadcasting and silencing our Prometheus alerts.
+
+## Requirements
+
+ * AWS access
+ * CredHub CLI
+ * `amtool` - the Alertmanager CLI
+
+Install `amtool` with `go get github.com/prometheus/alertmanager/cmd/amtool`
+
+## Before you start
+
+**1.** [Get credentials](/guides/Connecting_to_Concourse_CredHub_and_BOSH/) to
+talk to Alertmanager
+
+**2.** Navigate to Alertmanager's web UI
+
+For example:
+
+| Env | URL |
+| --- | --- |
+| Dev | `https://alertmanager-1.tlwr.cloudpipeline.digital` |
+| Staging | `https://alertmanager-1.london.staging.cloudpipeline.digital` |
+| London | `https://alertmanager-1.london.cloud.service.gov.uk` |
+| Ireland | `https://alertmanager-1.cloud.service.gov.uk` |
+
+**3.** Check you can talk to Alertmanager
+
+```
+amtool \
+  --alertmanager.url=https://admin:<PASSWORD>@alertmanager-1.tlwr.dev.cloudpipeline.digital \
+  config show
+```
+
+where `<PASSWORD>` is the Alertmanager password from CredHub
+
+_The following `amtool` commands assume that you specify `--alertmanager.url`_
+
+## Checking where alerts go
+
+Alertmanager has a concept of "routes", which dictate where alerts are routed
+
+You can list routes:
+
+```
+amtool config routes show
+```
+
+which will print:
+
+```
+Routing tree:
+.
+└── default-route  receiver: critical-receiver
+    ├── {severity="warning"}  continue: true  receiver: warning-receiver
+    ├── {severity="critical"}  continue: true  receiver: critical-receiver
+    ├── {notify="pagerduty-24-7"}  continue: true  receiver: pagerduty-24-7-receiver
+    └── {notify="pagerduty-in-hours"}  receiver: pagerduty-in-hours-receiver
+```
+
+You can see which route would be selected for an imaginary alert:
+
+```
+amtool config routes test severity=warning otherlabel=mylabelvalue
+```
+
+prints:
+
+```
+warning-receiver
+```
+
+and
+
+```
+amtool config routes test notify=pagerduty-24-7 otherlabel=foo
+```
+
+prints
+
+```
+pagerduty-24-7-receiver
+```
+
+## Simulating an alert
+
+**1.** Notify your colleagues that you are going to be testing alerts
+
+**2.** Add an override in PagerDuty
+
+_You may wish to override both the engineer and the comms schedules, so that
+only you are called_
+
+**3.** Create an alert that will expire in 5 minutes
+
+```
+amtool alert add \
+  this-is-a-test-alert \
+  notify=pagerduty-in-hours \
+  --end="$(date -v +5M -u '+%Y-%m-%dT%H:%M:%SZ')"
+```
+
+**4.** Await your phone call from PagerDuty, and resolve the incident

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -35,6 +35,7 @@
  - [How to release bosh blobs](guides/releasing_bosh_blobs/)
  - [How to run `paas-cf` tests locally](guides/running_paas-cf_tests_locally/)
  - [How to rotate credentials](team/rotating_credentials/)
+ - [How to test Alertmanager](guides/test_alertmanager/)
 
 ### Other information
  - [Our orgs on the paas](team/our_orgs_on_the_paas/)


### PR DESCRIPTION
What
----

Document how to test Alertmanager is hooked up to PagerDuty

How to review
-------------

Read the docs

_Rendered image_
![rendered image](https://user-images.githubusercontent.com/1482692/96096035-4abb4600-0ec7-11eb-8e66-1231cfa98a2f.png)
