### PR TITLE
responding to alerts: add section on cell disk usage being near full

### DIFF
--- a/source/support/responding_to_alerts.html.md
+++ b/source/support/responding_to_alerts.html.md
@@ -245,8 +245,7 @@ As this is the first monitor of this type please investigate the gorouters to di
 
 ## Diego cell ephemeral disk usage near full
 
-In the short term, to prevent a tenant-visible issue, it's probably a good idea to recreate
-the cell in bosh:
+To prevent a tenant-visible issue in the short term, it's probably a good idea to recreate the cell in bosh:
 
 ```
 cd ${PAAS_BOOTSTRAP_DIR}

--- a/source/support/responding_to_alerts.html.md
+++ b/source/support/responding_to_alerts.html.md
@@ -242,3 +242,22 @@ If you see an alert for gorouter latency being high;
 * Contact the team who own the service to see if they are aware of anything happening
 
 As this is the first monitor of this type please investigate the gorouters to discover the issue they are encountering. We have previously seen high resource usage (CPU and Memory) these should be checked in the first case.
+
+## Diego cell ephemeral disk usage near full
+
+In the short term, to prevent a tenant-visible issue, it's probably a good idea to recreate
+the cell in bosh:
+
+```
+cd ${PAAS_BOOTSTRAP_DIR}
+DEPLOY_ENV=prod make prod bosh-cli
+bosh restart diego-cell/123
+```
+
+In the long term, this should be investigated because it Shouldn't Happen. The grootfs
+garbage collector should keep disk space under control, so perhaps this is a sign that
+it isn't working properly.
+
+The [last time this happened](https://docs.google.com/document/d/1727mhApwfZdDafc0qPzPaJg_000JvzqfPCfFCKhLPqY/edit?ts=60f0422c#)
+we weren't quick enough investigating it and the logs fell out of logit, preventing us
+from diagnosing the true cause. So don't make the same mistake.


### PR DESCRIPTION
What
----

Add section describing actions to take if a diego cell's ephemeral disk usage is near full. We weren't able to diagnose the true cause of this because we let the issue fall out of our log retention, but the next person to encounter it would probably appreciate being told what action will make the immediate danger go away.

How to review
-------------

Read it.

Who can review
--------------

Anyone with taste.
