### PR TITLE
Update oauth docs for concourse 7

### DIFF
--- a/source/guides/Github_oAuth_in-Dev.html.md
+++ b/source/guides/Github_oAuth_in-Dev.html.md
@@ -8,7 +8,7 @@ This will enable anyone on the team to be able to log into your concourse
 
  - Create an [oAuth application](https://github.com/settings/applications/new)
  - Set your homepage URL to `https://deployer.<your env>.dev.cloudpipeline.digital`
- - Authorization callback URL should be `https://deployer.<your env>.dev.cloudpipeline.digital/auth/github/callback`
+ - Authorization callback URL should be `https://deployer.<your env>.dev.cloudpipeline.digital/sky/issuer/callback`
  - Store the client ID and Client secret in your personal pass store under the following locations `github.com/concourse/dev/client_id` and `github.com/concourse/dev/client_secret`
  - Run `make dev upload-github-oauth GITHUB_PASSWORD_STORE_DIR=<your pass dir> DEPLOY_ENV=<your env>`
  - Checkout Master and push the pipeline with the following command for deployer concourse


### PR DESCRIPTION


What
----

Concourse 7 changed so that dex sends the location of the redirect_uri to github

https://github.com/concourse/concourse/issues/6551#issuecomment-781622203

This means it has to match the callback url.

This needs to match what it is currently, which is fly/issuer/callback

How to review
-------------

Spin up the docs locally. And make sure that github auth works with the new url

Who can review
--------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.
