### PR TITLE
[#181819839] Deprecate the ADRS for New Billing

### DIFF
--- a/source/architecture_decision_records/ADR0048_add_resources_table.md
+++ b/source/architecture_decision_records/ADR0048_add_resources_table.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Deprecated
 
 ## Context
 
@@ -25,3 +25,8 @@ The `resources` table also acts as an audit point within GOV.UK PaaS billing. It
 This makes billing easier to support. It also makes billing run much more quickly since we do not need to go through all the Cloud Foundry events whenever we need to calculate tenant bills. With this method we can calculate tenants' bills on-demand, rather than calculating all bills in advance as original GOV.UK PaaS billing system did, so it opens up the possibility of the following:
     - Calculating bills between any 2 dates and times quickly
     - It is easier to break down bills by org, space, etc., or, later on, by annotation
+
+## Deprecation
+
+In the first quarter of 2022 we chose to suspend work on the new billing system, and revert to the old one. The decision 
+was prompted by a mix of performance issues in the new code base, and team capacity and prioritisation concerns. 

--- a/source/architecture_decision_records/ADR0049_calculate_bills.md
+++ b/source/architecture_decision_records/ADR0049_calculate_bills.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Deprecated.
 
 ## Context
 
@@ -31,3 +31,8 @@ All we need for this is to have different code entry points into billing. We can
 - Display bills for RDS for all tenants, for example.
 
 We can also easily tailor the billing reports in step 1 by different output fields, and enable reports to be filtered by input field (e.g. get bills just for RDS Postgres for a tenant, for example).
+
+## Deprecation
+
+In the first quarter of 2022 we chose to suspend work on the new billing system, and revert to the old one. The decision
+was prompted by a mix of performance issues in the new code base, and team capacity and prioritisation concerns. 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -155,3 +155,5 @@ This section contains Architecture Decision Records (ADR) as described in this b
  - [ADR-045 AWS WAF and WAF Log access by AWS DDoS Response Team](architecture_decision_records/ADR045-aws-waf/)
  - [ADR-046 Postgres Service Plans](architecture_decision_records/ADR046-postgres-plans/)
  - [ADR-047 Postgres allowed-extensions approach](architecture_decision_records/ADR047-postgres-extensions-approach/)
+ - [~ADR-048 Billing: Include record for services/resources provisioned for tenants~](architecture_decision_records/ADR0048_add_resources_table/)
+ - [~ADR-049 Billing: Decouple what we're calculating bills for from how the bills are calculated~](architecture_decision_records/Decouple what we're calculating bills for from how the bills are calculated/)


### PR DESCRIPTION
What
----

We made the decision to halt our plans for a new and improved billing engine. As part of the tidy up, we should mark the ADRs we wrote as deprecated.

How to review
-------------

1. Copy review
2. Does the strike through work on the index page?
