### PR TITLE
Prevent search engine bots from indexing

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -22,3 +22,6 @@ ga_tracking_id:
 max_toc_heading_level: 6
 
 enable_search: true
+
+# Prevent robots from indexing
+prevent_indexing: true


### PR DESCRIPTION
What
----

Config option adds <meta name="robots" content="noindex"> tag in the <head>

Partial revert of https://github.com/alphagov/paas-team-manual/pull/200 as we no longer use google search so no indexing required anymore

