### PR TITLE
185550872 - Fix Slack notification message

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "Deployment of ${{ github.event.pull_request.html_url }} FAILED"
+              "text": "Deployment of Paas Team Manual with commit ${{ github.sha }} FAILED."
             }
         env:
           SLACK_WEBHOOK_URL: ${{secrets.SLACK_WEBHOOK_URL}}


### PR DESCRIPTION
Description:
----
- Slack notification message on failure was previously empty as the event that triggers the workflow is no longer pull requests but merging into main
- The message now posts the commit SHA when a deployment fails

How to review
-------------

Code review.
