### PR TITLE
Update MacOS GPG installation instructions

### DIFF
--- a/source/guides/GPG.html.md
+++ b/source/guides/GPG.html.md
@@ -12,9 +12,9 @@ haven't used GPG recently or ever at all.
 
 ## Install
 
-On Mac OS X:
+On MacOS:
 
-    brew install gpg gpg-agent
+    brew install gpg
 
 On Ubuntu:
 


### PR DESCRIPTION
What
----

gpg-agent now ships with gnupg package: https://github.com/Homebrew/homebrew-core/commit/965e130e04e5900e35bf1f0b6ebad9d1c2f680a7

Also update name of MacOS

Who can review
--------------

Current PaaS team members
